### PR TITLE
Nfs content volume

### DIFF
--- a/docs/plugin-installation-and-configuration.md
+++ b/docs/plugin-installation-and-configuration.md
@@ -294,7 +294,25 @@ blacklist {
         wwid .*
 }
 ```
-The user must check their configuration and ensure that such a line is not present. If it is, it must be removed to allow the plugin to work properly with multipath volumes.
+The user must check their configuration and ensure that such a line is NOT present. If it is, it must be removed to allow the plugin to work properly with multipath volumes.
+
+Also to avoid unnecessary volumes to be managed by multipath, it is recommended to `blacklist` by vendor. If user choose to do so, he also have to set exception for JovianDSS volumes.
+Example of multipath blacklist and blacklist exception is provided below.
+
+```
+blacklist {
+    device {
+        vendor ".*"
+    }
+}
+
+blacklist_exceptions {
+    device {
+        vendor "SCST_BIO"
+    }
+}
+```
+
 
 ### Content volume
 

--- a/docs/plugin-installation-and-configuration.md
+++ b/docs/plugin-installation-and-configuration.md
@@ -1,0 +1,359 @@
+Welcome to the JovianDSS-Proxmox wiki!
+# JovianDSS-Proxmox
+
+## Docs
+
+Please visit [wiki](https://github.com/open-e/JovianDSS-Proxmox/wiki) for more information.
+1. [Quick Start](https://github.com/open-e/JovianDSS-Proxmox/wiki/Quick-Start)
+2. [JovianDSS recovery from a major storage failure](https://github.com/open-e/JovianDSS-Proxmox/wiki/JovianDSS-recovery-from-a-major-storage-failure)
+3. [Connecting to JovianDSS Virtual IP's on Proxmox](https://github.com/open-e/JovianDSS-Proxmox/wiki/Network-configuration)
+
+
+## Configuring
+
+Enabling JovianDSS for `proxmox` require 2 configuration files.
+First is a proxmox storage configuration file that gives basic information about storage.
+And the second is a config used by a minimal joviandss cli `jdssc`.
+
+### JovianDSS configuration
+
+Prior to installation please ensure that services mentioned below are enabled on JovianDSS storage:
+1. REST in `System Settings->Administration`
+
+
+### Proxmox config
+
+This config provides brief introduce Open-E JovianDSS plugin to proxmox storage sub-system.
+And contains minimal set of information required by perl part to run.
+
+`/etc/pve/storage.cfg` 
+
+```
+joviandss: jdss-Pool-0
+          pool_name Pool-0
+          config /etc/pve/jdss-170.yaml
+          content iso,backup,images,rootdir,vztmpl
+          content_volume_name proxmox-content-jdss-pool-0-nfs
+          content_volume_size 100
+          # option is available since v0.9.9
+          content_volume_type nfs
+          path /mnt/jdss-Pool-0-nfs
+          shared 1
+          debug 0
+          multipath 0
+          disable 0
+```
+
+| Option                     | Default value                     | Description                                                         |
+|----------------------------|-----------------------------------|---------------------------------------------------------------------|
+| `pool_name`                | Pool-0                            | Pool name that is going to be used. Must be created in \[1\]        |
+| `config`                   | /etc/pve/jdss-\<pool\_name\>.yaml | Path to `jdssc` configuration file                                  |
+| `content`                  | None                              | List content type that you expect JovianDSS to store. Supported values: iso,backup,images,rootdir,vztmpl |
+| `content_volume_name`      | None                              | Dedicated volume that would be used to store content resources. Only lowercase, numbers and symbols - . are allowed, this field is required |
+| `content_volume_size`      | 100                               | Size of content volume, measured in Gigabytes                       |
+| `content_volume_type`      | 'iscsi'                           | Specifies protocol to use to provide content volume. Available options are `nfs` and `iscsi`. This option is available since version v0.9.9 |
+| `path`                     | /mnt/proxmox-content-jdss-\<pool\_name\> | Location that would be used to mount proxmox dedicated volume |
+| `shared`                   | 0                                 | Migrate flag, setting this flag indicate that plugin support VM and Container migration. It is recommended to enable this flag.|
+| `debug`                    | 0                                 | Debuging flag, place 1 to enable                                    |
+| `multipath`                | 0                                 | Multipath flag, place 1 to enable                                   |
+| `disabled`                 | 0                                 | Flag that instructs Proxmox not to use this storage. Setting this flag will not result in volume deactivation or unmounting |
+
+
+[1] [Can be created by going to JovianDSS Web interface/Storage](https://www.open-e.com/site_media/download/documents/Open-E-JovianDSS-Advanced-Metro-High-Avability-Cluster-Step-by-Step-2rings.pdf)
+
+`content_volume` is a dedicated volume that is responsible for storing `iso`, `vztmpl` and `backup` files created and managed by proxmox.
+Plugin will go through configuration options and allocate content volume according to configuration provided in `storage.cfg`.
+This implies that plugin will create `nas-volume` if `NFS` is enabled as protocol or will create `volume` accessible through `iSCSI` if user specify `iscsi` as `content_volume_type`.
+In both cases `content_volume_name` will be used as a name for a new volume.
+User should keep in mind that name space for content volumes are common inside JovianDSS.
+And therefore user cannon have 2 different volumes for `NFS` and `iSCSI` protocols.
+
+
+### Jdssc config
+
+This config file should be placed according to the path provided in `storage.cfg` file mentioned in the section above.
+`joviandss.yaml` provides detailed information on interaction with storage.
+
+```yaml
+driver_use_ssl: True
+driver_ssl_cert_verify: False
+target_prefix: 'iqn.2021-10.iscsi:'
+jovian_block_size: '16K'
+jovian_rest_send_repeats: 3
+rest_api_addresses:
+  - '192.168.21.100'
+rest_api_port: 82
+target_port: 3260
+rest_api_login: 'admin'
+rest_api_password: 'admin'
+thin_provision: True
+loglevel: info
+logfile: /var/log/jdss-Pool-0.log
+```
+
+| Option                     | Default value           | Description                                                         |
+|----------------------------|-------------------------|---------------------------------------------------------------------|
+| `driver_use_ssl`           | True                    | Use TLS/SSL to send requests to JovianDSS\[1\]                      |
+| `driver_ssl_cert_verify`   | True                    | Verify TLS/SSL certificates of JovianDSS                            |
+| `iscsi_target_prefix`      | iqn.2021-10.iscsi:      | Prefix that will be used to form target name for volume             |
+| `jovian_block_size`        | 16K                     | Block size of a new volume, can be: 16K, 32K, 64K, 128K, 256K, 512K, 1M  |
+| `jovian_rest_send_repeats` | 3                       | Number of times that driver will try to send REST request           |
+| `rest_api_addresses`           |                         | Yaml list of IP address of the JovianDSS, only addresses specified here would be used for multipathing, [check for more network related information](https://github.com/open-e/JovianDSS-Proxmox/wiki/Network-configuration) |
+| `rest_api_port`             | 82                      | Rest port according to the settings in \[1\]                        |
+| `target_port`              | 3260                    | Port for iSCSI connections                                          |
+| `rest_api_login`                | admin                   | Must be set according to the settings in \[1\]                      |
+| `rest_api_password`             | admin                   | Jovian password \[1\], **should be changed** for security purposes  |
+| `thin_provision`       | False                   | Using thin provisioning for new volumes                             |
+| `loglevel`                 |                         | Logging level. Both `loglvl` and `logfile` have to be specified in order to make logging operational. Possible log levels are: critical, error, warning, info, debug |
+| `logfile`                  |                         | Path to file to store logs.                                         |
+
+
+[1] Can be enabled by going to JovianDSS Web interface/System Settings/REST Access
+
+[2] [Can be created by going to JovianDSS Web interface/Storage](https://www.open-e.com/site_media/download/documents/Open-E-JovianDSS-Advanced-Metro-High-Avability-Cluster-Step-by-Step-2rings.pdf)
+
+[More info about Open-E JovianDSS](http://blog.open-e.com/?s=how+to)
+
+### Multiple Pools
+
+Plugin allows proxmox use multiple joviandss `Pool` at a same time.
+To introduce new `Pool` to proxmox user have to duplicate storage section in `storage.cfg`.
+
+Make sure that variables `pool_name`, `path` and `content_volume_name` are different.
+Here is an example of presenting 2 pools `Pool-0` and `Pool-1` to `Proxmox` as 2 independent storage's `jdss-Pool-0` and `jdss-Pool-1` using `joviandss` plugin.
+
+```
+joviandss: jdss-Pool-0
+        pool_name Pool-0
+        config /etc/pve/jdss-Pool-0.yaml
+        content iso,backup,images,rootdir,vztmpl
+        content_volume_name proxmox-content-jdss-pool-0
+        # option is available since v0.9.9
+        content_volume_type nfs
+        content_volume_size 100
+        path /mnt/jdss-Pool-0
+        shared 1
+        debug 0
+        multipath 0
+
+joviandss: jdss-Pool-1
+        pool_name Pool-1
+        config /etc/pve/jdss-Pool-1.yaml
+        content iso,backup,images,rootdir,vztmpl
+        content_volume_name proxmox-content-jdss-pool-1
+        # option is available since v0.9.9
+        content_volume_type nfs
+        content_volume_size 100
+        path /mnt/jdss-Pool-1
+        shared 1
+        debug 0
+        multipath 0
+```
+
+And here is 2 `config` files referenced in `storage.cfg` file above:
+
+`/etc/pve/jdss-Pool-0.yaml`
+```yaml
+driver_use_ssl: True
+driver_ssl_cert_verify: False
+target_prefix: 'iqn.2021-10.iscsi:'
+jovian_block_size: '16K'
+jovian_rest_send_repeats: 3
+rest_api_addresses:
+  - '192.168.21.100'
+rest_api_port: 82
+target_port: 3260
+rest_api_login: 'admin'
+rest_api_password: 'admin'
+thin_provision: True
+loglevel: info
+logfile: /var/log/jdss-Pool-0.log
+```
+
+`/etc/pve/jdss-Pool-1.yaml`
+```yaml
+driver_use_ssl: True
+driver_ssl_cert_verify: False
+target_prefix: 'iqn.2021-10.iscsi:'
+jovian_block_size: '16K'
+jovian_rest_send_repeats: 3
+rest_api_addresses:
+  - '192.168.22.100'
+rest_api_port: 82
+target_port: 3260
+rest_api_login: 'admin'
+rest_api_password: 'admin'
+thin_provision: True
+loglevel: info
+logfile: /var/log/jdss-Pool-1.log
+```
+
+
+## Multipathing
+
+In order to enable multipathing user should provide a set of modifications to `storage.cfg`, `jdss-Pool-0.yaml` and `multipath.conf`
+
+For instance if user wants to enable multipathing on for storage `jdss-Pool-0` described in config files as:
+
+
+`/etc/pve/storage.cfg`
+```
+joviandss: jdss-Pool-0
+        pool_name Pool-0
+        config /etc/pve/jdss-Pool-0.yaml
+        content iso,backup,images,rootdir,vztmpl
+        content_volume_name proxmox-content-jdss-pool-0
+        # option is available since v0.9.9
+        content_volume_type nfs
+        content_volume_size 100
+        path /mnt/jdss-Pool-0
+        shared 1
+        debug 0
+        multipath 0
+```
+
+`/etc/pve/jdss-Pool-0.yaml`
+```yaml
+driver_use_ssl: True
+driver_ssl_cert_verify: False
+target_prefix: 'iqn.2021-10.iscsi:'
+jovian_block_size: '16K'
+jovian_rest_send_repeats: 3
+rest_api_addresses:
+  - '192.168.21.100'
+rest_api_port: 82
+target_port: 3260
+rest_api_login: 'admin'
+rest_api_password: 'admin'
+thin_provision: True
+loglevel: info
+logfile: /tmp/jdss.log
+```
+
+He should apply following changes:
+
+### storage.cfg
+
+Set `multipath` option to `1`
+
+`/etc/pve/storage.cfg`
+```
+joviandss: jdss-Pool-0
+        pool_name Pool-0
+        config /etc/pve/jdss-Pool-0.yaml
+        content iso,backup,images,rootdir,vztmpl
+        content_volume_name proxmox-content-jdss-pool-0
+        # option is available since v0.9.9
+        content_volume_type nfs
+        content_volume_size 100
+        path /mnt/jdss-Pool-0
+        shared 1
+        debug 0
+        multipath 1
+```
+
+### jdss-Pool-0.yaml
+
+Provide list of ip's that would be used for multipathing in `rest_api_addresses` property.
+
+`/etc/pve/jdss-Pool-0.yaml`
+```yaml
+driver_use_ssl: True
+driver_ssl_cert_verify: False
+target_prefix: 'iqn.2021-10.iscsi:'
+jovian_block_size: '16K'
+jovian_rest_send_repeats: 3
+rest_api_addresses:
+  - '192.168.21.100'
+  - '192.168.31.100'
+rest_api_port: 82
+target_port: 3260
+rest_api_login: 'admin'
+rest_api_password: 'admin'
+thin_provision: True
+loglevel: info
+logfile: /tmp/jdss.log
+```
+### multipath.conf
+
+Make sure that multipath service is present 
+
+```bash
+apt install multipath-tools sg3-utils
+```
+Make sure that multipath service is running:
+```bash
+systemctl enable multipathd
+systemctl start multipathd
+systemctl status multipathd
+```
+Starting with version 0.9.7, the plugin uses the SCSI ID wwid to serve multipath volumes. Because of this, users should avoid blacklisting by wwid:
+
+```
+blacklist {
+        wwid .*
+}
+```
+The user must check their configuration and ensure that such a line is not present. If it is, it must be removed to allow the plugin to work properly with multipath volumes.
+
+### Content volume
+
+Content volume is a dedicated volume that is allocated on JovianDSS for storing container templates, backups, iso.
+Since version v0.9.9 plugin provides 2 types of content volumes: `NFS` and `iSCSI`.
+User can create content volume `content_volume_name` manually or let JovianDSS proxmox plugin create it automatically.
+After activation plugin will try to mount content volume to directory specified as `path` in `storage.conf` file.
+
+`NFS` volume will be mounted straight away, but `iSCSI` volume will require manual formatting.
+
+Plugin will show path of device representation is OS through error message in web interface ![fs-error](pic/fs-error.png)
+
+Or in command line:
+```bash
+pvesm list jdss-Pool-0
+```
+
+Will output address `/dev/mapper/iqn.2021-10.com.open-e:proxmox-content-jdss-pool-0` for volume `proxmox-content-jdss-Pool-0`.
+```bash
+Unable identify file system type for content storage, if that is a first run, format /dev/mapper/iqn.2021-10.com.open-e:proxmox-content-jdss-Pool-0 to a file system of your choise. at /usr/share/perl5/PVE/Storage/Custom/OpenEJovianDSSPlugin.pm line 1010.
+```
+
+Formatting can be done by calling
+
+```bash
+mkfs.ext3 /dev/mapper/iqn.2021-10.com.open-e:proxmox-content-jdss-Pool-0
+```
+
+## Installing/Uninstalling
+
+### Install from source 
+
+Installation can be done by `make` inside source code folder
+
+```bash
+apt install python3-oslo.utils git
+git clone https://github.com/open-e/JovianDSS-Proxmox.git
+cd ./JovianDSS-Proxmox
+make install
+```
+
+Removing proxmox plugin with `jdssc`
+```bash
+make uninstall
+```
+### Installation for `deb` package
+Or by installing it from debian package
+
+```bash
+apt install ./open-e-joviandss-proxmox-plugin_0.9.5-1.deb
+```
+
+Once installation is done, provide configuration.
+
+After installation and configuration restart proxmox service.
+
+```bash
+systemctl restart pvedaemon
+```
+### Clustering
+
+Plugin have to be installed and configured on all nodes in cluster.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,82 @@
+This guide provides brief description on how to quickly setup JovianDSS Proxmox plugin on a single proxmox server.
+
+## Installing plugin
+
+Download latest `deb` package from [github](https://github.com/open-e/JovianDSS-Proxmox/releases).
+
+Use `apt` package manager to install package.
+```bash
+apt install ./open-e-joviandss-proxmox-plugin_0.9.9-1.deb
+```
+
+## Configuring plugin
+
+Add storage pool record to `storage.cfg`. Make sure that option `pool_name` stores proper pool name that you are using on your JovianDSS instance.
+
+`/etc/pve/storage.cfg` 
+
+```
+joviandss: jdss-Pool-0-nfs
+          pool_name Pool-0
+          config /etc/pve/jdss-170.yaml
+          content iso,backup,images,rootdir,vztmpl
+          content_volume_name proxmox-content-jdss-pool-0-nfs
+          content_volume_size 100
+          # option is available since v0.9.9
+          content_volume_type nfs
+          path /mnt/jdss-Pool-0-nfs
+          shared 1
+```
+
+
+Create a `yaml` file `/etc/pve/jdss-Pool-0.yaml` that contains detailed information on how to connect to your `JovianDSS` server.
+keep in mind that path to this file should be provided in file above in property `config`.
+
+`/etc/pve/jdss-Pool-0.yaml`
+```yaml
+driver_use_ssl: True
+driver_ssl_cert_verify: False # Option is available since v0.9.8
+target_prefix: 'iqn.2021-10.iscsi:'
+jovian_block_size: '16K'
+jovian_rest_send_repeats: 3
+rest_api_addresses:
+  - '192.168.21.100'
+rest_api_port: 82
+target_port: 3260
+rest_api_login: 'admin'
+rest_api_password: 'admin'
+thin_provision: True
+loglevel: info
+logfile: /var/log/jdss-Pool-0.log
+```
+
+## Troubleshooting
+
+### Connectivity issues
+Possible source of failure during start is incorrect network configuration.
+User can verify connectivity by pinging IP addresses specified in `/etc/pve/jdss-Pool-0.yaml` config.
+```bash
+root@pve:~# ping -c 5 192.168.21.100
+```
+In everything is OK `ping` output will look like:
+```
+PING 172.16.0.220 (172.16.0.220) 56(84) bytes of data.
+64 bytes from 192.168.21.100: icmp_seq=1 ttl=64 time=0.258 ms
+64 bytes from 192.168.21.100: icmp_seq=2 ttl=64 time=0.336 ms
+64 bytes from 192.168.21.100: icmp_seq=3 ttl=64 time=0.323 ms
+64 bytes from 192.168.21.100: icmp_seq=4 ttl=64 time=0.357 ms
+64 bytes from 192.168.21.100: icmp_seq=5 ttl=64 time=0.291 ms
+
+--- 192.168.21.100 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 4101ms
+rtt min/avg/max/mdev = 0.258/0.313/0.357/0.034 ms
+```
+In case of error
+```
+root@pve:~# ping -c 5 192.168.21.100
+PING 192.168.21.100 (192.168.21.100) 56(84) bytes of data.
+
+--- 192.168.21.100 ping statistics ---
+5 packets transmitted, 0 received, 100% packet loss, time 4079ms
+```
+Possible source of problem might be routing issues, in that case check [network configuration guide](https://github.com/open-e/JovianDSS-Proxmox/wiki/Network-configuration)

--- a/jdssc/bin/jdssc
+++ b/jdssc/bin/jdssc
@@ -61,7 +61,12 @@ def get_config():
     command = parser.add_subparsers(required=True, dest='command')
 
     command.add_parser('pool', add_help=False)
-    command.add_parser('hosts', add_help=False)
+    host_parser = command.add_parser('hosts', add_help=False)
+    host_parser.add_argument('-i', '--iscsi',
+                             dest='iscsi',
+                             action='store_true',
+                             default=False,
+                             help='Add iscsi port along side host address')
 
     args = parser.parse_known_args()
     return args
@@ -144,8 +149,9 @@ def duplicate_config_options(cfg):
 def hosts(args, uargs, jdss):
     for i in jdss.configuration['san_hosts']:
         addr = i
-        if 'target_port' in jdss.configuration:
-            addr = '%s:%s' % (addr, jdss.configuration['target_port'])
+        if 'iscsi' in args and args['iscsi']:
+            if 'target_port' in jdss.configuration:
+                addr = '%s:%s' % (addr, jdss.configuration['target_port'])
         sys.stdout.write(addr + "\n")
 
 

--- a/jdssc/jdssc/jovian_common/driver.py
+++ b/jdssc/jdssc/jovian_common/driver.py
@@ -1707,7 +1707,6 @@ class JovianDSSDriver(object):
         except jexc.JDSSResourceExistsException:
             LOG.debug("Looks like nas volume %s already exists", share_name)
 
-        sharename = jcom.vname(share_name)
         path = "{}/{}".format(self._pool, sharename)
 
         self.ra.create_share(sharename, path,

--- a/jdssc/jdssc/jovian_common/rest.py
+++ b/jdssc/jdssc/jovian_common/rest.py
@@ -1240,6 +1240,8 @@ class JovianRESTAPI(object):
             if "message" in resp["error"]:
                 if self.no_space_left.match(resp["error"]["message"]):
                     raise jexc.JDSSResourceExhausted
+                if self.dataset_exists_msg.match(resp["error"]["message"]):
+                    raise jexc.JDSSVolumeExistsException(volume_name)
                 if self.resource_already_exists_msg.match(
                         resp["error"]["message"]):
                     raise jexc.JDSSVolumeExistsException(volume_name)

--- a/jdssc/jdssc/nasvolume.py
+++ b/jdssc/jdssc/nasvolume.py
@@ -47,6 +47,29 @@ class NASVolumes():
         create = parsers.add_parser('create')
         create.add_argument('nas_volume_name', type=str,
                             help='New nas volume name')
+        create.add_argument('-s',
+                            '--size',
+                            required=True,
+                            dest='volume_size',
+                            type=str,
+                            default='1G',
+                            help='New volume size in format num + [M G T]')
+        create.add_argument('-b',
+                            dest='block_size',
+                            type=str,
+                            default=None,
+                            choices=block_size_options,
+                            help=('Block size of new volume, default is 16K'))
+        create.add_argument('-d',
+                            dest='direct_mode',
+                            action='store_true',
+                            default=False,
+                            help='Use real volume name')
+        create.add_argument('-n',
+                            required=True,
+                            dest='volume_name',
+                            type=str,
+                            help='New volume name')
 
         nas_volume_parser.add_argument(
             'nas_volume_name', help='NSA volume name')

--- a/jdssc/jdssc/pool.py
+++ b/jdssc/jdssc/pool.py
@@ -18,10 +18,13 @@ import sys
 
 from jdssc.jovian_common import driver
 import jdssc.cifs as cifs
-import jdssc.nas_volumes as nas_volumes
-import jdssc.volumes as volumes
-import jdssc.volume as volume
+import jdssc.nasvolumes as nasvolumes
+import jdssc.shares as shares
+import jdssc.share as share
 import jdssc.targets as targets
+import jdssc.volume as volume
+import jdssc.volumes as volumes
+
 
 """Pool related commands."""
 
@@ -32,7 +35,9 @@ class Pools():
         self.pa = {'cifs': self.cifs,
                    'get': self.get,
                    'ip': self.ip,
-                   'nas_volumes': self.nas_volumes,
+                   'nas_volumes': self.nasvolumes,
+                   'share': self.share,
+                   'shares': self.shares,
                    'targets': self.targets,
                    'volume': self.volume,
                    'volumes': self.volumes}
@@ -62,6 +67,8 @@ class Pools():
         parsers.add_parser('ip', add_help=False)
         parsers.add_parser('cifs', add_help=False)
         parsers.add_parser('nas_volumes', add_help=False)
+        parsers.add_parser('share', add_help=False)
+        parsers.add_parser('shares', add_help=False)
         parsers.add_parser('targets', add_help=False)
         parsers.add_parser('volume', add_help=False)
         parsers.add_parser('volumes', add_help=False)
@@ -82,8 +89,14 @@ class Pools():
             line = ("%s\n" % i)
             sys.stdout.write(line)
 
-    def nas_volumes(self):
-        nas_volumes.NASVolumes(self.args, self.uargs, self.jdss)
+    def share(self):
+        share.Share(self.args, self.uargs, self.jdss)
+
+    def shares(self):
+        shares.Shares(self.args, self.uargs, self.jdss)
+
+    def nasvolumes(self):
+        nasvolumes.NASVolumes(self.args, self.uargs, self.jdss)
 
     def volume(self):
         volume.Volume(self.args, self.uargs, self.jdss)

--- a/jdssc/jdssc/share.py
+++ b/jdssc/jdssc/share.py
@@ -1,0 +1,142 @@
+#    Copyright (c) 2024 Open-E, Inc.
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import argparse
+import sys
+import uuid
+import logging
+
+from jdssc.jovian_common import exception as jexc
+
+LOG = logging.getLogger(__name__)
+
+"""Share related commands."""
+
+
+class Share():
+    def __init__(self, args, uargs, jdss):
+
+        self.share_action = {'delete': self.delete,
+                             'get': self.get,
+                             'resize': self.resize}
+
+        self.args = args
+        args, uargs = self.__parse(uargs)
+
+        self.args.update(vars(args))
+        self.uargs = uargs
+        self.jdss = jdss
+
+        action = args.share_action
+        if ((action is not None) and
+                (len(action) > 0) and
+                (action in self.share_action)):
+            self.share_action[action]()
+        else:
+            sys.exit(1)
+
+    def __parse(self, args):
+
+        share_parser = argparse.ArgumentParser(prog="Share")
+
+        share_parser.add_argument('share_name', help='Volume name')
+
+        parsers = share_parser.add_subparsers(dest='share_action')
+
+        delete = parsers.add_parser('delete')
+        delete.add_argument('-d',
+                            dest='direct_mode',
+                            action='store_true',
+                            default=False,
+                            help='Print actual share names')
+        get = parsers.add_parser('get')
+        get.add_argument('-d',
+                         dest='direct_mode',
+                         action='store_true',
+                         default=False,
+                         help='Use exact volume name')
+        get.add_argument('-s',
+                         dest='share_size',
+                         action='store_true',
+                         default=False,
+                         help='Print share quota size')
+        get.add_argument('-G',
+                         dest='share_gigabyte_size',
+                         action='store_true',
+                         default=False,
+                         help='Print share size in gigabytes')
+
+        resize = parsers.add_parser('resize')
+        resize.add_argument('--add',
+                            dest="add_size",
+                            action="store_true",
+                            default=False,
+                            help='Add new size to existing volume size')
+        resize.add_argument('new_size',
+                            type=str,
+                            help='New volume size')
+        resize.add_argument('-d',
+                            dest='direct_mode',
+                            action='store_true',
+                            default=False,
+                            help='Use real volume name')
+
+        kargs, ukargs = share_parser.parse_known_args(args)
+
+        if kargs.share_action is None:
+            share_parser.print_help()
+            sys.exit(1)
+
+        return kargs, ukargs
+
+    def get(self):
+
+        try:
+            d = self.jdss.get_nas_volume(self.args['share_name'],
+                                         direct_mode=self.args['direct_mode'])
+
+        except jexc.JDSSException as err:
+            LOG.error(err.message)
+            exit(1)
+
+        if self.args['share_size']:
+            if self.args['share_gigabyte_size']:
+                print(int(int(d['quota'])/(1024*1024*1024)))
+            else:
+                print(d['quota'])
+
+    def delete(self):
+
+        try:
+            self.jdss.delete_share(self.args['share_name'],
+                                   direct=self.args['share_name'])
+        except jexc.JDSSResourceNotFoundException:
+            LOG.debug(("NAS volume $s do not exists, "
+                      "treat deletion as complete."),
+                      self.args['share_name'])
+
+    def resize(self):
+
+        share_name = self.args['share_name']
+
+        size = self.args['new_size']
+
+        if self.args['add_size']:
+            d = self.jdss.get_share(share_name,
+                                    direct_mode=self.args['direct_mode'])
+            size += int(d['size'])
+
+        self.jdss.resize_share(share_name, size,
+                               direct_mode=self.args['direct_mode'])

--- a/jdssc/jdssc/share.py
+++ b/jdssc/jdssc/share.py
@@ -111,6 +111,7 @@ class Share():
             LOG.error(err.message)
             exit(1)
 
+        LOG.debug("nas volume data %s", str(d))
         if self.args['share_size']:
             if self.args['share_gigabyte_size']:
                 print(int(int(d['quota'])/(1024*1024*1024)))

--- a/share.py
+++ b/share.py
@@ -41,8 +41,8 @@ class Shares():
         action = args.shares_action
         if ((action is not None) and
                 (len(action) > 0) and
-                (action in self.shares_action)):
-            self.shares_action[action]()
+                (action in self.sharesaction)):
+            self.sharesaction[action]()
         else:
             sys.exit(1)
 
@@ -85,16 +85,6 @@ class Shares():
                            action='store_true',
                            default=False,
                            help='Show only volumes with VM ID')
-        listp.add_argument('-d',
-                           dest='direct_mode',
-                           action='store_true',
-                           default=False,
-                           help='Print actual share names')
-        listp.add_argument('-p',
-                           dest='path',
-                           action='store_true',
-                           default=False,
-                           help='Print share path')
 
         kargs, ukargs = shares_parser.parse_known_args(args)
 
@@ -126,12 +116,17 @@ class Shares():
             LOG.error("No space left on the storage")
             exit(1)
 
-    def list(self):
-        data = self.jdss.list_shares()
-        LOG.debug(data)
-        for v in data:
+    def get(self):
 
-            line = ("%(name)s %(path)s\n" % {
-                    'name': v['name'],
-                    'path': v['path']})
-            sys.stdout.write(line)
+        volume_name = self.args['volume_name']
+
+        volume = {'id': volume_name}
+
+        d = self.jdss.get_volume(volume)
+
+        if self.args['volume_size']:
+            print(d['size'])
+
+    def delete(self):
+
+        self.jdss.delete_share(self.args['share_name'])

--- a/tests/testcases/plugin/content-volume/content-volume-disabled.yaml
+++ b/tests/testcases/plugin/content-volume/content-volume-disabled.yaml
@@ -1,0 +1,61 @@
+name: Content volume disabled
+prerequisites: 
+    - Plugin installed on Proxmox
+    - JovianDSS have Pool-0
+    - JovianDSS have Pool-1
+    - JovianDSS have REST enabled
+    - Plugin and jdssc is not configured
+    - Multipath is not configured
+setup:
+id: content-volume-disabled-001
+scenario: |
+    User starts proxmox with 2 Pools provided by JovianDSS
+    User enables basic configuration without content volume
+description: |
+    Test that verifies that plugin is capable of operating without content volume in config
+objective: |
+    ensure that content volume will not be automaticaly created and mounted unless it is defined
+    storage.cfg
+steps:
+    - Add test-jdss-Pool-1 description to proxmox storage.cfg
+    - Add jdss-170.yaml to /etc/pve/ folder according to storage.conf
+    - desc: Run command that list resources on test-jdss-Pool-1 and inits content volume as a side effect
+      cmd: pvesm list test-jdss-Pool-1
+    - desc: Ensure that content volume do not exists on JovianDSS storage and it is not mounted anywhere
+      cmd: mount
+data:
+    - desc: Content of jdss-170.yaml file
+      value: |
+        driver_use_ssl: True
+        driver_ssl_cert_verify: False
+        target_prefix: 'iqn.2021-10.iscsi.170:'
+        jovian_block_size: '16K'
+        jovian_rest_send_repeats: 3
+        rest_api_addresses:
+          - '172.28.140.170'
+        rest_api_port: 82
+        target_port: 3260
+        rest_api_login: 'admin'
+        rest_api_password: 'admin'
+        thin_provision: True
+        loglevel: debug
+        logfile: /var/log/jdss-170-Pool-0.log
+      name: jdss-170.yaml
+    - desc: Content of storage.cfg file
+      value: |
+        joviandss: test-jdss-Pool-1
+          pool_name Pool-1
+          config /etc/pve/jdss-170.yaml
+          content images
+          content_volume_name proxmox-content-jdss-pool-nas-1
+          content_volume_size 10
+          content_volume_type nfs
+          debug 0
+          multipath 1
+          path /mnt/test-jdss-Pool-1
+          shared 1
+      name: storage.cfg
+parameters:
+references:
+expected_results: |
+    Content storages do not get created

--- a/tests/testcases/plugin/content-volume/multiproto-content-vol.yaml
+++ b/tests/testcases/plugin/content-volume/multiproto-content-vol.yaml
@@ -1,0 +1,70 @@
+name: Pool that serves multiple content volumes
+prerequisites: 
+    - Plugin installed on Proxmox
+    - JovianDSS have Pool-0
+    - JovianDSS have REST enabled
+    - Plugin and jdssc is not configured
+    - Multipath is not configured
+setup:
+id: multi-content-volume-001
+scenario: |
+    User starts proxmox with Pool-0 provided by JovianDSS
+    And configures multiple content volumes on same Pool-0
+description: |
+    Test that verifies that user can configure iscsi and nfs pool on same pool
+objective: |
+    ensure that plugin is capable of providing multiple content volumes for single pool
+steps:
+    - Add test-jdss-Pool-0-nfs description to proxmox storage.cfg
+    - Add test-jdss-Pool-0-iscsi description to proxmox storage.cfg
+    - desc: Run command that list resources on test-jdss-Pool-0-iscsi and test-jdss-Pool-0-nfs
+      cmd: |
+           pvesm list test-jdss-Pool-0-iscsi
+           pvesm list test-jdss-Pool-0-nfs
+    - desc: Ensure that content volume exists for test-jdss-Pool-0-iscsi test-jdss-Pool-0-nfs
+data:
+    - desc: Content of jdss-170.yaml file
+      value: |
+        driver_use_ssl: True
+        driver_ssl_cert_verify: False
+        target_prefix: 'iqn.2021-10.iscsi.170:'
+        jovian_block_size: '16K'
+        jovian_rest_send_repeats: 3
+        rest_api_addresses:
+          - '172.28.140.170'
+        rest_api_port: 82
+        target_port: 3260
+        rest_api_login: 'admin'
+        rest_api_password: 'admin'
+        thin_provision: True
+        loglevel: debug
+        logfile: /var/log/jdss-170-Pool-0.log
+      name: jdss-170.yaml
+    - desc: Content of storage.cfg file
+      value: |
+        joviandss: test-jdss-Pool-0-iscsi
+          pool_name Pool-0
+          config /etc/pve/jdss-170.yaml
+          content images
+          content_volume_name proxmox-content-jdss-pool-iscsi-0
+          content_volume_size 10
+          content_volume_type iscsi
+          multipath 1
+          path /mnt/test-jdss-Pool-0-iscsi
+          shared 1
+        joviandss: test-jdss-Pool-0-nfs
+          pool_name Pool-0
+          config /etc/pve/jdss-170.yaml
+          content images
+          content_volume_name proxmox-content-jdss-pool-nfs-0
+          content_volume_size 10
+          content_volume_type nfs
+          multipath 1
+          path /mnt/test-jdss-Pool-0-nfs
+          shared 1
+      name: storage.cfg
+parameters:
+references:
+expected_results: |
+    Both content volume get created and operational
+

--- a/tests/testcases/plugin/poolconfig/basic-multipool-nfs.yaml
+++ b/tests/testcases/plugin/poolconfig/basic-multipool-nfs.yaml
@@ -1,0 +1,86 @@
+name: Multiple pool entries with NFS content volumes
+prerequisites: 
+    - Plugin installed on Proxmox
+    - JovianDSS have Pool-0
+    - JovianDSS have Pool-1
+    - JovianDSS have REST enabled
+    - Plugin and jdssc is not configured
+    - Multipath is not configured
+    - Logging level for jdssc INFO
+setup:
+id: plugin-multiple-storages-001
+scenario: |
+    User starts proxmox with 2 Pools provided by JovianDSS and
+    configures both pools to have NFS based content volumes
+description: |
+    Test that verifys that plugin is capable of serving multiple nfs content volumes from different pools
+objective: ensure that plugin is capable of serving multiple nfs content volumes from different pools
+steps:
+    - Add test-jdss-Pool-0 description to proxmox storage.cfg 
+    - Add test-jdss-Pool-1 description to proxmox storage.cfg
+    - Add jdss-170.yaml to /etc/pve/ folder according to storage.conf
+    - desc: Run command that list resources on test-jdss-Pool-0 and inits content volume as a side effect
+      cmd: pvesm list test-jdss-Pool-0
+    - desc: Run command that list resources on test-jdss-Pool-1 and inits content volume as a side effect
+      cmd: pvesm list test-jdss-Pool-1
+    - desc: Ensure that content volume is mounted and looks like findmnt_ok
+      cmd: findmnt /mnt/test-jdss-Pool-0
+    - desc: Ensure that content volume is mounted and looks like findmnt_ok
+      cmd: findmnt /mnt/test-jdss-Pool-1
+data:
+    - desc: Content of jdss-170.yaml file
+      value: |
+        driver_use_ssl: True
+        driver_ssl_cert_verify: False
+        target_prefix: 'iqn.2021-10.iscsi.170:'
+        jovian_block_size: '16K'
+        jovian_rest_send_repeats: 3
+        rest_api_addresses:
+          - '172.28.140.170'
+        rest_api_port: 82
+        target_port: 3260
+        rest_api_login: 'admin'
+        rest_api_password: 'admin'
+        thin_provision: True
+        loglevel: debug
+        logfile: /var/log/jdss-170-Pool-0.log
+      name: jdss-170.yaml
+    - desc: Content of storage.cfg file
+      value: |
+        joviandss: test-jdss-Pool-0
+          pool_name Pool-0
+          config /etc/pve/jdss-170.yaml
+          content images,backup,vztmpl,iso,rootdir
+          content_volume_name proxmox-content-jdss-pool-nas-0
+          content_volume_size 10
+          content_volume_type nfs
+          debug 0
+          multipath 1
+          path /mnt/test-jdss-Pool-0
+          shared 1
+        joviandss: test-jdss-Pool-1
+          pool_name Pool-1
+          config /etc/pve/jdss-170.yaml
+          content images,backup,vztmpl,iso,rootdir
+          content_volume_name proxmox-content-jdss-pool-nas-1
+          content_volume_size 10
+          content_volume_type nfs
+          debug 0
+          multipath 1
+          path /mnt/test-jdss-Pool-1
+          shared 1
+      name: storage.cfg
+    - desc: Output example
+      name: findmnt_ok
+      value: |
+        TARGET           SOURCE                                                       FSTYPE OPTIONS
+        /jdss-Pool-0 192.168.21.100:/Pools/Pool-0/proxmox-content-jdss-pool-nas-0 nfs    rw,relatime,vers=3,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=192.168.21.100,mountvers=3,mountport=46451,mountproto=udp,local_lock=none,addr=192.168.21.100
+
+parameters:
+references:
+expected_results: |
+    Storages jdss-Pool-0 and jdss-Pool-1 get created
+    Content volumes get automaticaly created for both volumes
+    Containers get successfully created and their volumes present on both
+        pools respectively
+    Containers and their volumes get successfully deleted

--- a/tests/testcases/plugin/poolconfig/content-volume-nfs-size-change.yaml
+++ b/tests/testcases/plugin/poolconfig/content-volume-nfs-size-change.yaml
@@ -1,0 +1,44 @@
+name: Content volume nfs size change
+prerequisites: 
+    - Plugin installed on Proxmox
+    - JovianDSS have pool Pool-0
+    - JovianDSS have REST enabled
+    - Plugin and jdssc configured to according git installation guide and have nfs content volume
+    - Multipath is not configured
+    - Content volume attached
+    - Logging level for jdssc INFO
+setup:
+id: content-volume-nfs-size-change-001
+scenario: |
+    User starts proxmox with plugin configured to use pool TestPool and NAS volume content_volume.
+    User increase content_volume size by 20G in config and observer results.
+description: |
+    Test that verifys that auto volume resize works properly for nas volumes
+objective: |
+    Ensure that plugin is capable of automatic content volume resize
+    if content volume size get changed in config
+steps:
+    - Ensure that TestPool is configured in storage.cfg
+    - desc: Ensure that content_volume is enabled and mounted apropriatly
+      cmd: findmnt /mnt/jdss-TestPool
+    - Ensure that content_volume is NFS type
+    - Download container image to content volume
+    - Change content volume size in config
+    - Ensure that content volume have size increased
+    - Create containet test1 from image dowloaded before
+    - Ensure that container is accesable
+data:
+    - description: Pool name
+      value: TestPool
+      name: TestPool
+    - description: container name
+      value: test1
+      name: test1
+    - description: content volume name specified in config
+      value: proxmox-content-jdss-TestPool
+      name: content_volume
+parameters:
+references:
+expected_results: |
+    Content volume get resized and container get created.
+    Container image is not lost.

--- a/tests/testcases/plugin/start/first-start.yaml
+++ b/tests/testcases/plugin/start/first-start.yaml
@@ -1,0 +1,52 @@
+name: Content volume nfs first start
+prerequisites: 
+    - Plugin installed on Proxmox
+    - JovianDSS have pool Pool-0
+    - Plugin and jdssc configured to have single pool according git installation guide
+    - NFS share and NAS volume are not present Pool-0 
+    - Multipath is not configured
+    - Logging level for jdssc INFO
+setup:
+id: content-volume-nfs-init-001
+scenario: |
+    User starts proxmox with plugin configured to use Pool-0.
+    User opens console and lists resources for Pool-0 and observes output.
+description: |
+    First lpugin run after installation or after boot
+objective: |
+    Ensure that proxmox plugin capable of allocating and initializing
+    content volume on the basis of nfs protocol
+steps:
+    - desc: Ensure that Pool-0 is configured in storage.cfg
+    - desc: Run command that list resources on jdss-Pool-0 and inits content volume as a side effect
+      cmd: pvesm list jdss-Pool-0
+    - desc: Observe output
+    - desc: Ensure that content volume is mounted
+      cmd: findmnt /mnt/jdss-Pool-0
+data:
+    - desc: Pool name
+      value: Pool-0
+      name: Pool-0
+    - desc: Content of storage.cfg file
+      value: |
+        joviandss: jdss-Pool-0
+          pool_name Pool-0
+          config /etc/pve/jdss-Pool-0.yaml
+          content images,backup,vztmpl,iso,rootdir
+          content_volume_name proxmox-content-jdss-pool-nas-0
+          content_volume_size 102
+          content_volume_type nfs
+          debug 0
+          multipath 1
+          path /mnt/jdss-Pool-0
+          shared 1
+      name: storage.cfg
+    - desc: Output example
+      name: findmnt_ok
+      value: |
+        TARGET           SOURCE                                                       FSTYPE OPTIONS
+        /jdss-Pool-0 192.168.21.100:/Pools/Pool-0/proxmox-content-jdss-pool-nas-0 nfs    rw,relatime,vers=3,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=192.168.21.100,mountvers=3,mountport=46451,mountproto=udp,local_lock=none,addr=192.168.21.100
+parameters:
+references:
+expected_results: |
+    Content volume in fomr of NAS share provided over nfs get created and no addition debug or cmd related info get printed.

--- a/tests/testcases/plugin/volume-create/create-vm.yaml
+++ b/tests/testcases/plugin/volume-create/create-vm.yaml
@@ -1,0 +1,35 @@
+name: Create VM
+prerequisites: 
+    - Plugin installed on Proxmox
+    - JovianDSS have pool Pool-0
+    - JovianDSS have REST enabled
+    - Plugin and jdssc configured to have single pool according git installation guide
+    - Multipath is enabled
+    - Content volume attached
+    - Logging level for jdssc INFO
+setup:
+id: create-vm-001
+scenario: |
+    User creates vm with single volume and checks its size after creation
+description: |
+    Basic vm creation test with additional volume check
+objective: |
+    Ensure that plugin creates volume of proper size
+steps:
+    - desc: |
+        Create VM vm-101 with proxmox UI and in process secelt volume size to be 32G and stored on Pool-0
+    - desc: |
+        Check volume size
+      cmd: |
+        qemu-img info /dev/mapper/iqn.2021-10.iscsi.2:vm-101-disk-0-6deefee73c2a26c83062bc79d555f072169d2ed2ff8c77f3a4121be1d9dfc002
+data:
+    - description: Pool name
+      value: Pool-0
+      name: Pool-0
+    - description: vm name
+      value: 101
+      name: vm-101
+parameters:
+references:
+expected_results: |
+    file length: 32 GiB (34359738368 bytes)


### PR DESCRIPTION
Introduce NFS based content volumes along side with several fixes

Allows user to specify what protocol to use for content volume.

Remove redundant message printing to proxmox output
Make content_volume_name required property
Improve block device path identification for multipath
Fix volume creation logic that was adding additional KiB to volume during creation
Fix volume resize bug