### PR TITLE
Plugin rework

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 0.9.10-8
 Section: admin
 Priority: optional
 Architecture: all
-Depends: python3-oslo.utils (>= 3.36), python3-yaml (>= 3.13), multipath-tools, sg3-utils, patch, python3-retry
+Depends: python3-oslo.utils (>= 3.36), python3-yaml (>= 3.13), multipath-tools, sg3-utils, patch, python3-retry, libstring-util-perl
 Maintainer: andrei.perepiolkin@open-e.com
 Homepage: https://github.com/open-e/JovianDSS-Proxmox
 Description: Open-E JovianDSS plugin for proxmox

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: open-e-joviandss-proxmox-plugin
-Version: 0.9.10-8
+Version: 0.10.0-0
 Section: admin
 Priority: optional
 Architecture: all

--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -2,4 +2,5 @@
 
 chmod +x /usr/local/bin/jdssc
 mkdir -p /var/log/joviandss
+mkdir -p /etc/joviandss
 exit 0

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ install:
 	install -D -m 0644 ./OpenEJovianDSSPlugin.pm $(DESTDIR)/usr/share/perl5/PVE/Storage/Custom/OpenEJovianDSSPlugin.pm
 	install -D -m 0644 ./OpenEJovianDSSPluginLVM.pm $(DESTDIR)/usr/share/perl5/PVE/Storage/Custom/OpenEJovianDSSPluginLVM.pm
 	install -D -m 0644 ./OpenEJovianDSS/Common.pm $(DESTDIR)/usr/share/perl5/OpenEJovianDSS/Common.pm
-	install -D -m 0645 ./blockdevicemanager/joviandssblockdevicemanager $(DESTDIR)/usr/local/bin/joviandssblockdevicemanager
-	install -D -m 0645 ./blockdevicemanager/joviandss-block-device-manager.service $(DESTDIR)/etc/systemd/system/joviandss-block-device-manager.service
 
 	$(MAKE) -C jdssc install DESTDIR=$(DESTDIR)
 
@@ -36,6 +34,4 @@ uninstall:
 	@echo "Cleaning up proxmox plugin"
 	rm $(DESTDIR)/usr/share/perl5/PVE/Storage/Custom/OpenEJovianDSSPlugin.pm
 	rm $(DESTDIR)/usr/share/perl5/PVE/Storage/Custom/OpenEJovianDSSPluginLVM.pm
-	patch -R /usr/share/perl5/PVE/Storage/Plugin.pm ./mark-open-e-plugin-as-dynamic.patch
-	rm /usr/share/open-e/mark-open-e-plugin-as-dynamic.patch
 	$(MAKE) -C jdssc uninstall DESTDIR=$(DESTDIR)

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ install:
 	install -D -m 0644 ./OpenEJovianDSSPlugin.pm $(DESTDIR)/usr/share/perl5/PVE/Storage/Custom/OpenEJovianDSSPlugin.pm
 	install -D -m 0644 ./OpenEJovianDSSPluginLVM.pm $(DESTDIR)/usr/share/perl5/PVE/Storage/Custom/OpenEJovianDSSPluginLVM.pm
 	install -D -m 0644 ./OpenEJovianDSS/Common.pm $(DESTDIR)/usr/share/perl5/OpenEJovianDSS/Common.pm
+	install -D -m 0645 ./blockdevicemanager/joviandssblockdevicemanager $(DESTDIR)/usr/local/bin/joviandssblockdevicemanager
+	install -D -m 0645 ./blockdevicemanager/joviandss-block-device-manager.service $(DESTDIR)/etc/systemd/system/joviandss-block-device-manager.service
 
 	$(MAKE) -C jdssc install DESTDIR=$(DESTDIR)
 

--- a/OpenEJovianDSSPlugin.pm
+++ b/OpenEJovianDSSPlugin.pm
@@ -19,10 +19,12 @@ use strict;
 use warnings;
 
 use Data::Dumper;
+
 #use Encode   qw(decode encode);
 #use Storable qw(lock_store lock_retrieve);
 
 use File::Path qw(make_path);
+
 #use File::Temp qw(tempfile);
 use File::Basename;
 
@@ -36,10 +38,11 @@ use PVE::Tools qw($IPV6RE);
 #TODO: comment/uncomment to enable criticue operation
 use PVE::Storage;
 use PVE::Storage::Plugin;
+
 #use PVE::SafeSyslog;
 
 use OpenEJovianDSS::Common qw(:all);
-use base qw(PVE::Storage::Plugin);
+use base                   qw(PVE::Storage::Plugin);
 
 use constant COMPRESSOR_RE => 'gz|lzo|zst';
 
@@ -79,7 +82,6 @@ my $PLUGIN_VERSION = '0.10.0-0';
 #               localy
 
 # Configuration
-
 
 sub api {
 
@@ -150,8 +152,9 @@ sub properties {
             default     => OpenEJovianDSS::Common::get_default_user_name(),
         },
         user_password => {
-            description => "User password that will be used in REST communication",
-            type        => 'string',
+            description =>
+              "User password that will be used in REST communication",
+            type => 'string',
         },
         target_prefix => {
             description => "Prefix of iSCSI target 'iqn.2025-04.iscsi:'",
@@ -159,31 +162,37 @@ sub properties {
             default     => OpenEJovianDSS::Common::get_default_target_prefix,
         },
         ssl_cert_verify => {
-            description => "Enforce certificate verification for REST over SSL/TLS",
-            type        => 'boolean',
+            description =>
+              "Enforce certificate verification for REST over SSL/TLS",
+            type => 'boolean',
         },
         control_addresses => {
-            description => "Coma separated list of ip addresses, that will be used to send control REST requests to JovianDSS storage",
-            type        => 'string',
+            description =>
+"Coma separated list of ip addresses, that will be used to send control REST requests to JovianDSS storage",
+            type => 'string',
         },
         control_port => {
-            description => "Port number that will be used to send REST request, single for all addresses",
-            type        => 'string',
-            default     => OpenEJovianDSS::Common::get_default_control_port(),
+            description =>
+"Port number that will be used to send REST request, single for all addresses",
+            type    => 'string',
+            default => OpenEJovianDSS::Common::get_default_control_port(),
         },
         data_addresses => {
-            description => "Coma separated list of ip addresses, that will be used to transfer storage data(iSCSI data)",
-            type        => 'string',
+            description =>
+"Coma separated list of ip addresses, that will be used to transfer storage data(iSCSI data)",
+            type => 'string',
         },
         data_port => {
-            description => "Port number that will be used to transfer storage data(iSCSI data)",
-            type        => 'string',
-            default     => OpenEJovianDSS::Common::get_default_data_port(),
+            description =>
+"Port number that will be used to transfer storage data(iSCSI data)",
+            type    => 'string',
+            default => OpenEJovianDSS::Common::get_default_data_port(),
         },
         block_size => {
-            description => 'Block size for newly created volumes, allowed values are: '.
-                           '4K 8K 16K 32K 64K 128K 256K 512K 1M',
-            type        => 'string',
+            description =>
+              'Block size for newly created volumes, allowed values are: '
+              . '4K 8K 16K 32K 64K 128K 256K 512K 1M',
+            type => 'string',
         },
         thin_provisioning => {
             description => 'Create new volumes as thin',
@@ -236,8 +245,6 @@ $MULTIPATH = undef if !-X $MULTIPATH;
 my $SYSTEMCTL = '/usr/bin/systemctl';
 $SYSTEMCTL = undef if !-X $SYSTEMCTL;
 
-
-
 #sub check_iscsi_support {
 #    my $noerr = shift;
 #
@@ -253,7 +260,6 @@ $SYSTEMCTL = undef if !-X $SYSTEMCTL;
 #
 #    return 1;
 #}
-
 
 #sub iscsi_test_portal {
 #    my ($portal) = @_;
@@ -292,59 +298,64 @@ $SYSTEMCTL = undef if !-X $SYSTEMCTL;
 #        outfunc => sub { } );
 #}
 
-sub block_device_path {
-    my ( $class, $scfg, $volname, $storeid, $snapname, $content_volume_flag ) =
-      @_;
-
-    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Getting path of volume ${volname} " . OpenEJovianDSS::Common::safe_var_print( "snapshot", $snapname ) . "\n");
-
-    my $target = $class->get_target_name( $scfg, $volname, $snapname,
-        $content_volume_flag );
-
-    my $tpath;
-
-    if ( OpenEJovianDSS::Common::get_multipath($scfg) ) {
-        $tpath = $class->get_multipath_path( $scfg, $target );
-    }
-    else {
-        $tpath = $class->get_target_path( $scfg, $target, $storeid );
-    }
-
-    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Block device path is ${tpath} of volume ${volname} " . OpenEJovianDSS::Common::safe_var_print( "snapshot", $snapname ) . "\n");
-
-    return $tpath;
-}
+#sub block_device_path {
+#    my ( $class, $scfg, $volname, $storeid, $snapname, $content_volume_flag ) =
+#      @_;
+#
+#    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Getting path of volume ${volname} " . OpenEJovianDSS::Common::safe_var_print( "snapshot", $snapname ) . "\n");
+#
+#    my $target = $class->get_target_name( $scfg, $volname, $snapname,
+#        $content_volume_flag );
+#
+#    my $tpath;
+#
+#    if ( OpenEJovianDSS::Common::get_multipath($scfg) ) {
+#        $tpath = $class->get_multipath_path( $scfg, $target );
+#    }
+#    else {
+#        $tpath = $class->get_target_path( $scfg, $target, $storeid );
+#    }
+#
+#    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Block device path is ${tpath} of volume ${volname} " . OpenEJovianDSS::Common::safe_var_print( "snapshot", $snapname ) . "\n");
+#
+#    return $tpath;
+#}
 
 sub path {
     my ( $class, $scfg, $volname, $storeid, $snapname ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
     my ( $vtype, $name, $vmid ) = $class->parse_volname($volname);
 
     my $path;
 
     if ( $vtype eq "images" ) {
-        my $til = OpenEJovianDSS::Common::lun_record_local_get_info_list( $scfg, $storeid, $volname, $snapname );
+        my $til = OpenEJovianDSS::Common::lun_record_local_get_info_list( $scfg,
+            $storeid, $volname, $snapname );
 
-        if ( @$til == 1) {
-            my ($targetname, $lunid, $lunrecpath, $lr) = $til->[0];
-             return OpenEJovianDSS::Common::block_device_path_from_lun_rec( $scfg, $storeid, $targetname, $lunid, $lr );
+        if ( @$til == 1 ) {
+            my ( $targetname, $lunid, $lunrecpath, $lr ) = $til->[0];
+            return OpenEJovianDSS::Common::block_device_path_from_lun_rec(
+                $scfg, $storeid, $targetname, $lunid, $lr );
         }
 
         unless (@$til) {
-            my $bdpl = OpenEJovianDSS::Common::volume_activate( $scfg, $storeid, $vmid, $volname, $snapname, undef );
+            my $bdpl =
+              OpenEJovianDSS::Common::volume_activate( $scfg, $storeid, $vmid,
+                $volname, $snapname, undef );
 
-            unless( defined($bdpl) ) {
-                die "Unable to identify block device related to ${volname}" .
-                        OpenEJovianDSS::Common::safe_var_print( "snapshot", $snapname ) .
-                        "\n";
+            unless ( defined($bdpl) ) {
+                die "Unable to identify block device related to ${volname}"
+                  . OpenEJovianDSS::Common::safe_var_print( "snapshot",
+                    $snapname )
+                  . "\n";
             }
             return $bdpl[0];
         }
-        die "Resource ${volname}" .
-                OpenEJovianDSS::Common::safe_var_print( "snapshot", $snapname ) .
-                " have multiple records \n";
+        die "Resource ${volname}"
+          . OpenEJovianDSS::Common::safe_var_print( "snapshot", $snapname )
+          . " have multiple records \n";
 
     }
     else {
@@ -355,60 +366,58 @@ sub path {
 }
 
 sub rename_volume {
-    my ($class, $scfg, $storeid, $source_volname, $target_vmid, $target_volname) = @_;
+    my ( $class, $scfg, $storeid, $original_volname, $new_vmid, $new_volname )
+      = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
-    my ($source_vtype,
-        $source_volume_name,
-        $source_vmid,
-        $source_basename,
-        $source_basedvmid,
-        $source_isBase,
-        $source_format) = $class->parse_volname($source_volname);
+    my (
+        $original_vtype,    $original_volume_name, $original_vmid,
+        $original_basename, $original_basedvmid,   $original_isBase,
+        $original_format
+    ) = $class->parse_volname($source_volname);
 
-    $target_volname = $class->find_free_diskname($storeid, $scfg, $target_vmid, $source_format) if (! defined($target_volname));
+    $new_volname =
+      $class->find_free_diskname( $storeid, $scfg, $new_vmid, $source_format )
+      if ( !defined($new_volname) );
 
-    my $til = OpenEJovianDSS::Common::lun_record_local_get_info_list( $scfg, $storeid, $source_volname, undef );
+    my $til =
+      OpenEJovianDSS::Common::lun_record_local_get_info_list( $scfg, $storeid,
+        $original_volname, undef );
 
-    if ( @$til == 1) {
+    if ( @$til == 1 ) {
 
-        ($targetname, $lunid, $lunrecpath, $lr) = $til->[0];
-        OpenEJovianDSS::Common::lun_record_local_create(
-                $scfg,    $storeid,
-                $targetname, $lunid, $target_volname, undef,
-                $lr->{scsiid}, $lr->{size},
-                $lr->{multipath}, $lr->{shared},
-                @{ $lr->{hosts} }
-        )
-
+        ( $targetname, $lunid, $lunrecpath, $lr ) = $til->[0];
+        $lr->{volname} = $new_volname;
+        OpenEJovianDSS::Common::lun_record_local_update( $scfg, $storeid,
+            $targetname, $lunid, $lr->{volname}, undef, $lr );
         eval {
             OpenEJovianDSS::Common::joviandss_cmd(
                 $scfg,
                 [
-                    "pool", $pool,
-                    "volume", $source_volname,
-                    "rename", $target_volname
+                    "pool",   $pool, "volume", $original_volname,
+                    "rename", $new_volname
                 ]
             );
-        }
-        my $err = $@;
+        } my $err = $@;
 
         if ($err) {
             eval {
-                OpenEJovianDSS::Common::lun_record_local_delete( $scfg, $storeid, $targetname, $lunid, $target_volname, undef );
-                die "Unable to rename volume ${volname} because of ${err}\n";
+                OpenEJovianDSS::Common::lun_record_local_delete( $scfg,
+                    $storeid, $targetname, $lunid, $new_volname, undef );
+                die
+"Unable to rename volume ${original_volname} to ${new_volname} because of ${err}\n";
             }
         }
-        OpenEJovianDSS::Common::lun_record_local_delete( $scfg, $storeid, $targetname, $lunid, $source_volname, undef );
+        OpenEJovianDSS::Common::lun_record_local_delete( $scfg, $storeid,
+            $targetname, $lunid, $original_volname, undef );
         return;
-
+    }
     unless (@$til) {
         OpenEJovianDSS::Common::joviandss_cmd(
             $scfg,
             [
-                "pool", $pool,
-                "volume", $source_volname,
+                "pool",   $pool, "volume", $source_volname,
                 "rename", $target_volname
             ]
         );
@@ -425,22 +434,18 @@ sub create_base {
 
     $class->deactivate_volume( $storeid, $scfg, $volname, undef, undef );
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
     my $newnameprefix = join '', 'base-', $vmid, '-disk-';
 
-    my $newname = OpenEJovianDSS::Common::joviandss_cmd(
-        $scfg,
-        [
-            "pool",     $pool,
-            "volumes",
-            "getfreename", "--prefix", $newnameprefix
-        ]
+    my $newname = OpenEJovianDSS::Common::joviandss_cmd( $scfg,
+        [ "pool", $pool, "volumes", "getfreename", "--prefix", $newnameprefix ]
     );
     chomp($newname);
     $newname =~ s/[^[:ascii:]]//;
 
-    $class->rename_volume( $scfg, $storeid, $source_volname, $volname, $vmid, $target_volname );
+    $class->rename_volume( $scfg, $storeid, $source_volname, $volname, $vmid,
+        $target_volname );
 
     return $newname;
 }
@@ -448,30 +453,27 @@ sub create_base {
 sub clone_image {
     my ( $class, $scfg, $storeid, $volname, $vmid, $snap ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
     my ( undef, undef, undef, undef, undef, undef, $fmt ) =
       $class->parse_volname($volname);
     my $clone_name = $class->find_free_diskname( $storeid, $scfg, $vmid, $fmt );
 
-    my $size = OpenEJovianDSS::Common::joviandss_cmd(
-        $scfg,
-        [
-            "pool", $pool,
-            "volume", $volname,
-            "get", "-s"
-        ] );
+    my $size = OpenEJovianDSS::Common::joviandss_cmd( $scfg,
+        [ "pool", $pool, "volume", $volname, "get", "-s" ] );
     $size = OpenEJovianDSS::Common::clean_word($size);
 
-    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Clone ${volname} with size ${size} to ${clone_name}" . OpenEJovianDSS::Common::safe_var_print( " with snapshot", $snap ) . "\n");
+    OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+            "Clone ${volname} with size ${size} to ${clone_name}"
+          . OpenEJovianDSS::Common::safe_var_print( " with snapshot", $snap )
+          . "\n" );
     if ($snap) {
         OpenEJovianDSS::Common::joviandss_cmd(
             $scfg,
             [
-                "pool",  $pool,
-                "volume", $volname,
-                "clone", "--size", $size, "--snapshot", $snap, "-n",
-                $clone_name
+                "pool",  $pool,    "volume", $volname,
+                "clone", "--size", $size,    "--snapshot",
+                $snap,   "-n",     $clone_name
             ]
         );
     }
@@ -479,9 +481,9 @@ sub clone_image {
         OpenEJovianDSS::Common::joviandss_cmd(
             $scfg,
             [
-                "pool",  $pool,
-                "volume", $volname,
-                "clone", "--size", $size, "-n", $clone_name
+                "pool",  $pool,    "volume", $volname,
+                "clone", "--size", $size,    "-n",
+                $clone_name
             ]
         );
     }
@@ -490,7 +492,7 @@ sub clone_image {
 
 sub alloc_image {
     my ( $class, $storeid, $scfg, $vmid, $fmt, $name, $size ) = @_;
-
+,
     my $volume_name = $name;
 
     $volume_name = $class->find_free_diskname( $storeid, $scfg, $vmid, $fmt )
@@ -498,38 +500,35 @@ sub alloc_image {
 
     if ( 'images' ne "${fmt}" ) {
 
-        my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+        my $pool    = OpenEJovianDSS::Common::get_pool($scfg);
         my $extsize = $size * 1024;
         OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
-            "Creating volume ${volume_name} format ${fmt} requested size ${size}\n"
+"Creating volume ${volume_name} format ${fmt} requested size ${size}\n"
         );
 
         my $create_vol_cmd = [
-            "pool", $pool,
-            "volumes", 
-            "create", "--size", "${extsize}", "-n", $volume_name
+            "pool",   $pool,        "volumes", "create",
+            "--size", "${extsize}", "-n",      $volume_name
         ];
 
         my $block_size = OpenEJovianDSS::Common::get_block_size($scfg);
-        my $thin_provisioning = OpenEJovianDSS::Common::get_thin_provisioning($scfg);
+        my $thin_provisioning =
+          OpenEJovianDSS::Common::get_thin_provisioning($scfg);
 
-        if (defined($thin_provisioning)) {
+        if ( defined($thin_provisioning) ) {
             push @$create_vol_cmd, '--thin-provisioning', $thin_provisioning;
         }
 
-        if (defined($block_size)) {
+        if ( defined($block_size) ) {
             push @$create_vol_cmd, '--block-size', $block_size;
         }
 
-        OpenEJovianDSS::Common::joviandss_cmd(
-            $scfg,
-            $create_vol_cmd
-        );
+        OpenEJovianDSS::Common::joviandss_cmd( $scfg, $create_vol_cmd );
 
-        if (OpenEJovianDSS::Common::get_shared($scfg)) {
-            my $tgname = OpenEJovianDSS::Common::get_vm_target_group_name($scfg, $vmid);
-            OpenEJovianDSS::Common::activate_volume_shared( $scfg, $storeid, $tgname, $volname );
-        }
+#if (OpenEJovianDSS::Common::get_shared($scfg)) {
+#    my $tgname = OpenEJovianDSS::Common::get_vm_target_group_name($scfg, $vmid);
+#    OpenEJovianDSS::Common::activate_volume_shared( $scfg, $storeid, $tgname, $volname );
+#}
     }
     return "$volume_name";
 }
@@ -537,7 +536,7 @@ sub alloc_image {
 sub free_image {
     my ( $class, $storeid, $scfg, $volname, $isBase, $_format ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
     my ( $vtype, undef, $vmid, undef, undef, undef, $format ) =
       $class->parse_volname($volname);
 
@@ -546,38 +545,31 @@ sub free_image {
             $format );
     }
     OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
-        "Deleting volume ${volname} format ${format}\n"
-    );
+        "Deleting volume ${volname} format ${format}\n" );
 
+    my $tgname = OpenEJovianDSS::Common::get_vm_target_group_name($scfg, $vmid);
     my $prefix = OpenEJovianDSS::Common::get_target_prefix($scfg);
 
     # Volume deletion will result in deletetion of all its snapshots
     # Therefore we have to detach all volume snapshots that is expected to be
     # removed along side with volume
-    my $delitablesnaps = OpenEJovianDSS::Common::joviandss_cmd(
-        $scfg,
-        [
-            "pool", $pool,
-            "volume", $volname,
-            "delete", "-c", "-p", '--target-prefix', $prefix
-        ]
-    );
-    my @dsl = split( " ", $delitablesnaps );
 
-    foreach my $snap (@dsl) {
-        OpenEJovianDSS::Common::volume_deactivate ( $scfg, $storeid, $vmid, $volname, $snap, undef );
+    OpenEJovianDSS::Common::volume_deactivate( $scfg, $storeid, $vmid,
+        $volname, undef, undef );
 
-    }
-
-    OpenEJovianDSS::Common::volume_deactivate ( $scfg, $storeid, $vmid, $volname, undef, undef );
+    # Deactivation does not unpublish volumes, only snapshots
+    OpenEJovianDSS::Common::volume_unpublish (
+        $scfg, $storeid, $vmid, $volname, undef, undef );
 
     OpenEJovianDSS::Common::joviandss_cmd(
         $scfg,
         [
-            "pool", $pool,
-            "volume", $volname,
-            "delete", "-c", '--target-prefix', $prefix
-        ] );
+            "pool",     $pool,
+            "volume",   $volname,
+            "delete", "-c",  '--target-prefix', $prefix,
+            '--target-group-name', $tgname
+        ]
+    );
     return undef;
 }
 
@@ -620,8 +612,6 @@ sub free_image {
 #        }
 #    }
 #}
-
-
 
 #sub stage_multipath {
 #    my ( $class, $scfg, $scsiid, $target ) = @_;
@@ -752,17 +742,17 @@ sub free_image {
 #    die "Unable to restart the multipath daemon $@\n" if $@;
 #}
 
-sub get_expected_multipath_path {
-    my ( $class, $scfg, $target ) = @_;
-
-    if ( defined $target && length $target ) {
-
-        my $mpath = "/dev/mapper/${target}";
-
-        return $mpath;
-    }
-    return undef;
-}
+#sub get_expected_multipath_path {
+#    my ( $class, $scfg, $target ) = @_;
+#
+#    if ( defined $target && length $target ) {
+#
+#        my $mpath = "/dev/mapper/${target}";
+#
+#        return $mpath;
+#    }
+#    return undef;
+#}
 
 sub get_iscsi_addresses {
     my ( $class, $scfg, $storeid, $port ) = @_;
@@ -776,7 +766,7 @@ sub get_iscsi_addresses {
     my $out = OpenEJovianDSS::Common::joviandss_cmd( $scfg, $getaddressesscmd );
     my @hosts = ();
     foreach ( split( /\n/, $out ) ) {
-            push @hosts, split;
+        push @hosts, split;
     }
     return @hosts;
 }
@@ -787,9 +777,9 @@ sub get_nfs_addresses {
     my $gethostscmd = [ "hosts", '--nfs' ];
 
     my @hosts = ();
-    my $out = OpenEJovianDSS::Common::joviandss_cmd($scfg, $gethostscmd);
+    my $out   = OpenEJovianDSS::Common::joviandss_cmd( $scfg, $gethostscmd );
     foreach ( split( /\n/, $out ) ) {
-            push @hosts, OpenEJovianDSS::Common::clean_word(split);
+        push @hosts, OpenEJovianDSS::Common::clean_word(split);
     }
     return @hosts;
 }
@@ -812,7 +802,8 @@ sub get_scsiid {
             };
 
             if ($@) {
-                die "Unable to get the iSCSI ID for ${targetpath} because of $@\n";
+                die
+"Unable to get the iSCSI ID for ${targetpath} because of $@\n";
             }
         }
         else {
@@ -821,7 +812,8 @@ sub get_scsiid {
 
         if ( defined($scsiid) ) {
             if ( $scsiid =~ /^([\-\@\w.\/]+)$/ ) {
-                OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Identified scsi id ${1}\n");
+                OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+                    "Identified scsi id ${1}\n" );
                 return $1;
             }
         }
@@ -835,12 +827,10 @@ sub get_target_name {
     my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
     my $prefix = OpenEJovianDSS::Common::get_target_prefix($scfg);
 
-    my $get_target_cmd =
-      [ 
-          "pool", $pool,
-          "targets",
-          "get", '--target-prefix', $prefix, "-v", $volname
-      ];
+    my $get_target_cmd = [
+        "pool",            $pool,   "targets", "get",
+        '--target-prefix', $prefix, "-v",      $volname
+    ];
     if ($snapname) {
         push @$get_target_cmd, "--snapshot", $snapname;
     }
@@ -850,7 +840,8 @@ sub get_target_name {
         }
     }
 
-    my $target = OpenEJovianDSS::Common::joviandss_cmd( $scfg, $get_target_cmd, 80, 3 );
+    my $target =
+      OpenEJovianDSS::Common::joviandss_cmd( $scfg, $get_target_cmd, 80, 3 );
 
     if ( defined($target) ) {
         $target = OpenEJovianDSS::Common::clean_word($target);
@@ -862,39 +853,34 @@ sub get_target_name {
       . OpenEJovianDSS::Common::safe_var_print( "snapshot", $snapname );
 }
 
-sub get_target_path {
-    my ( $class, $scfg, $target, $storeid, $expected ) = @_;
-
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
-
-    my @hosts = $class->get_iscsi_addresses( $scfg, $storeid, 1 );
-
-    my $path;
-    foreach my $host (@hosts) {
-        $path = "/dev/disk/by-path/ip-${host}-iscsi-${target}-lun-0";
-        if ( defined $expected && $expected != 0 ) {
-            return $path;
-        }
-        if ( -e $path ) {
-            return $path;
-        }
-    }
-    return undef;
-}
+#sub get_target_path {
+#    my ( $class, $scfg, $target, $storeid, $expected ) = @_;
+#
+#    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+#
+#    my @hosts = $class->get_iscsi_addresses( $scfg, $storeid, 1 );
+#
+#    my $path;
+#    foreach my $host (@hosts) {
+#        $path = "/dev/disk/by-path/ip-${host}-iscsi-${target}-lun-0";
+#        if ( defined $expected && $expected != 0 ) {
+#            return $path;
+#        }
+#        if ( -e $path ) {
+#            return $path;
+#        }
+#    }
+#    return undef;
+#}
 
 sub list_images {
     my ( $class, $storeid, $scfg, $vmid, $vollist, $cache ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
     #TODO: rename jdssc variable
-    my $jdssc = OpenEJovianDSS::Common::joviandss_cmd(
-        $scfg,
-        [
-            "pool", $pool,
-            "volumes",
-            "list", "--vmid"
-        ] );
+    my $jdssc = OpenEJovianDSS::Common::joviandss_cmd( $scfg,
+        [ "pool", $pool, "volumes", "list", "--vmid" ] );
 
     my $res = [];
     foreach ( split( /\n/, $jdssc ) ) {
@@ -929,29 +915,24 @@ sub list_images {
 sub volume_snapshot {
     my ( $class, $scfg, $storeid, $volname, $snap ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
     my ( $vtype, $name, $vmid ) = $class->parse_volname($volname);
 
-    OpenEJovianDSS::Common::joviandss_cmd(
-        $scfg,
-        [
-            "pool",      $pool,
-            "volume", $volname,
-            "snapshots",
-            "create", $snap
-        ]
-    );
+    OpenEJovianDSS::Common::joviandss_cmd( $scfg,
+        [ "pool", $pool, "volume", $volname, "snapshots", "create", $snap ] );
 
 }
+
 # Returns a hash with the snapshot names as keys and the following data:
 # id        - Unique id to distinguish different snapshots even if the have the same name.
 # timestamp - Creation time of the snapshot (seconds since epoch).
 # Returns an empty hash if the volume does not exist.
 sub volume_snapshot_info {
-    my ($class, $scfg, $storeid, $volname) = @_;
+    my ( $class, $scfg, $storeid, $volname ) = @_;
 
-    return OpenEJovianDSS::Common::joviandss_volume_snapshot_info($scfg, $storeid, $volname);
+    return OpenEJovianDSS::Common::joviandss_volume_snapshot_info( $scfg,
+        $storeid, $volname );
 }
 
 sub volume_snapshot_needs_fsfreeze {
@@ -962,53 +943,40 @@ sub volume_snapshot_needs_fsfreeze {
 sub volume_snapshot_rollback {
     my ( $class, $scfg, $storeid, $volname, $snap ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
     OpenEJovianDSS::Common::joviandss_cmd(
         $scfg,
         [
-            "pool",     $pool,
-            "volume", $volname,
-            "snapshot", $snap,
-            "rollback", "do"
+            "pool",     $pool, "volume",   $volname,
+            "snapshot", $snap, "rollback", "do"
         ]
     );
 }
 
-
 sub volume_rollback_is_possible {
-    my ($class, $scfg, $storeid, $volname, $snap, $blockers) = @_;
+    my ( $class, $scfg, $storeid, $volname, $snap, $blockers ) = @_;
 
-    return OpenEJovianDSS::Common::joviandss_volume_rollback_is_possible($scfg, $storeid, $volname, $snap, $blockers);
+    return OpenEJovianDSS::Common::joviandss_volume_rollback_is_possible( $scfg,
+        $storeid, $volname, $snap, $blockers );
 }
 
 sub volume_snapshot_delete {
     my ( $class, $scfg, $storeid, $volname, $snap, $running ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
-
-    my $starget = OpenEJovianDSS::Common::get_active_target_name(
-        scfg     => $scfg,
-        volname  => $volname,
-        snapname => $snap
-    );
-    unless ( defined($starget) ) {
-        $starget = $class->get_target_name( $scfg, $volname, $snap );
-    }
-    $class->unstage_multipath( $scfg, $storeid, $starget )
-      if OpenEJovianDSS::Common::get_multipath($scfg);
-
-    $class->unstage_target( $scfg, $storeid, $starget );
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
     my ( $vtype, $name, $vmid ) = $class->parse_volname($volname);
+
+    OpenEJovianDSS::Common::volume_deactivate( $scfg, $storeid, $vmid,
+        $volname, $snap, undef );
 
     OpenEJovianDSS::Common::joviandss_cmd(
         $scfg,
         [
-            "pool", $pool,
-            "volume", $volname,
-            "snapshot", $snap,
-            "delete", '--target-prefix', $prefix
+            "pool",     $pool, "volume", $volname,
+            "snapshot", $snap, "delete", '--target-prefix',
+            $prefix
         ]
     );
 }
@@ -1016,17 +984,10 @@ sub volume_snapshot_delete {
 sub volume_snapshot_list {
     my ( $class, $scfg, $storeid, $volname ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
-    my $jdssc = OpenEJovianDSS::Common::joviandss_cmd(
-        $scfg,
-        [
-            "pool", $pool,
-            "volume", $volname,
-            "snapshots",
-            "list"
-        ]
-    );
+    my $jdssc = OpenEJovianDSS::Common::joviandss_cmd( $scfg,
+        [ "pool", $pool, "volume", $volname, "snapshots", "list" ] );
 
     my $res = [];
     foreach ( split( /\n/, $jdssc ) ) {
@@ -1040,7 +1001,7 @@ sub volume_snapshot_list {
 sub volume_size_info {
     my ( $class, $scfg, $storeid, $volname, $timeout ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
     my ( $vtype, $name, $vmid ) = $class->parse_volname($volname);
 
@@ -1049,13 +1010,8 @@ sub volume_size_info {
             $timeout );
     }
 
-    my $size = OpenEJovianDSS::Common::joviandss_cmd(
-        $scfg,
-        [
-            "pool", $pool,
-            "volume", $volname,
-            "get", "-s" 
-        ] );
+    my $size = OpenEJovianDSS::Common::joviandss_cmd( $scfg,
+        [ "pool", $pool, "volume", $volname, "get", "-s" ] );
     chomp($size);
     $size =~ s/[^[:ascii:]]//;
 
@@ -1065,15 +1021,10 @@ sub volume_size_info {
 sub status {
     my ( $class, $storeid, $scfg, $cache ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
     my $jdssc =
-      OpenEJovianDSS::Common::joviandss_cmd( 
-          $scfg,
-          [
-              "pool", $pool,
-              "get"
-          ] );
+      OpenEJovianDSS::Common::joviandss_cmd( $scfg, [ "pool", $pool, "get" ] );
     my $gb = 1024 * 1024 * 1024;
     my ( $total, $avail, $used ) = split( " ", $jdssc );
 
@@ -1094,10 +1045,12 @@ sub ensure_content_volume_nfs {
         return undef;
     }
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
-    my $content_volume_name = OpenEJovianDSS::Common::get_content_volume_name($scfg);
-    my $content_volume_size = OpenEJovianDSS::Common::get_content_volume_size($scfg);
+    my $content_volume_name =
+      OpenEJovianDSS::Common::get_content_volume_name($scfg);
+    my $content_volume_size =
+      OpenEJovianDSS::Common::get_content_volume_size($scfg);
 
     my $content_volume_size_current = undef;
 
@@ -1109,49 +1062,58 @@ sub ensure_content_volume_nfs {
         $content_volume_size_current = OpenEJovianDSS::Common::joviandss_cmd(
             $scfg,
             [
-                'pool', $pool,
-                'share', $content_volume_name,
-                'get', '-d',    '-s',   '-G'
+                'pool', $pool, 'share', $content_volume_name,
+                'get',  '-d',  '-s',    '-G'
             ]
         );
     };
 
-    if ( ! defined($content_volume_size_current)) {
+    if ( !defined($content_volume_size_current) ) {
+
         # If we are not able to identify size of content volume
         # most likely it does not exists
         # there fore we have to create it
-        OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Creating content volume with size ${content_volume_size}\n");
+        OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+            "Creating content volume with size ${content_volume_size}\n" );
         OpenEJovianDSS::Common::joviandss_cmd(
             $scfg,
             [
-                'pool', $pool,
-                'shares',
-                'create', '-d', '-q', "${content_volume_size}G", '-n', $content_volume_name
+                'pool',   $pool, 'shares',
+                'create', '-d',  '-q', "${content_volume_size}G", '-n',
+                $content_volume_name
             ]
         );
-    } elsif (defined($content_volume_size_current) &&
-             $content_volume_size_current =~ /^\d+$/ &&
-             $content_volume_size_current > 0 ) {
+    }
+    elsif (defined($content_volume_size_current)
+        && $content_volume_size_current =~ /^\d+$/
+        && $content_volume_size_current > 0 )
+    {
 
         # TODO: check for volume size on the level of OS
         # If volume needs resize do it with jdssc
         die "Unable to identify content volume ${content_volume_name} size\n"
           unless defined($content_volume_size);
-        $content_volume_size_current = OpenEJovianDSS::Common::clean_word($content_volume_size_current);
-        OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Current content volume size ${content_volume_size_current}, config value ${content_volume_size}\n");
+        $content_volume_size_current =
+          OpenEJovianDSS::Common::clean_word($content_volume_size_current);
+        OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+"Current content volume size ${content_volume_size_current}, config value ${content_volume_size}\n"
+        );
         if ( $content_volume_size > $content_volume_size_current ) {
             OpenEJovianDSS::Common::joviandss_cmd(
                 $scfg,
                 [
-                    "pool", $pool,
-                    "share", $content_volume_name,
-                    "resize", "-d", "${content_volume_size}G"
+                    "pool",   $pool, "share", $content_volume_name,
+                    "resize", "-d",  "${content_volume_size}G"
                 ]
             );
         }
-    } else {
-        OpenEJovianDSS::Common::debugmsg( $scfg, "warning", "Unable to process current size of content volume <${content_volume_size_current}>, please make sure that JovianDSS is accessible over network\n");
-        die "Unable to process current size of content volume <${content_volume_size_current}>, please make sure that JovianDSS is accessible over network\n";
+    }
+    else {
+        OpenEJovianDSS::Common::debugmsg( $scfg, "warning",
+"Unable to process current size of content volume <${content_volume_size_current}>, please make sure that JovianDSS is accessible over network\n"
+        );
+        die
+"Unable to process current size of content volume <${content_volume_size_current}>, please make sure that JovianDSS is accessible over network\n";
     }
 
     my @hosts = $class->get_nfs_addresses( $scfg, $storeid );
@@ -1166,7 +1128,8 @@ sub ensure_content_volume_nfs {
         eval {
             $not_found_code = run_command( $cmd, outfunc => sub { } );
         };
-        OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Code for find mnt ${not_found_code}\n");
+        OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+            "Code for find mnt ${not_found_code}\n" );
         $class->ensure_fs($scfg);
 
         if ( $not_found_code eq 0 ) {
@@ -1174,7 +1137,8 @@ sub ensure_content_volume_nfs {
         }
     }
 
-    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Content storage found not to be mounted, mounting.\n");
+    OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+        "Content storage found not to be mounted, mounting.\n" );
 
     my $not_mounted = 1;
     eval {
@@ -1191,8 +1155,8 @@ sub ensure_content_volume_nfs {
         my $nfs_path       = "${host}:/Pools/${pool}/${content_volume_name}";
         run_command(
             [
-                "/usr/bin/mount",    "-t",
-                "nfs",               "-o",
+                "/usr/bin/mount",         "-t",
+                "nfs",                    "-o",
                 "vers=3,nconnect=4,sync", $nfs_path,
                 $content_path
             ],
@@ -1208,7 +1172,8 @@ sub ensure_content_volume_nfs {
         eval {
             $not_found_code = run_command( $cmd, outfunc => sub { } );
         };
-        OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Code for find mnt ${not_found_code}\n");
+        OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+            "Code for find mnt ${not_found_code}\n" );
 
         $class->ensure_fs($scfg);
 
@@ -1220,172 +1185,172 @@ sub ensure_content_volume_nfs {
     die "Unable to mount content storage\n";
 }
 
-sub ensure_content_volume {
-    my ( $class, $storeid, $scfg, $cache ) = @_;
-
-    my $content_path = OpenEJovianDSS::Common::get_content_path($scfg);
-
-    unless ( defined($content_path) ) {
-        return undef;
-    }
-
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
-
-    my $content_volname     = OpenEJovianDSS::Common::get_content_volume_name($scfg);
-    my $content_volume_size = OpenEJovianDSS::Common::get_content_volume_size($scfg);
-
-    # First we get expected path of block device representing content volume
-    # Block Device Path
-    my $til = OpenEJovianDSS::Common::lun_record_local_get_info_list( $scfg, $storeid, $source_volname, undef );
-
-    if ( @$til == 1) {
-
-        ($targetname, $lunid, $lunrecpath, $lr) = $til->[0];
-    }
-    #
-    my $block_devs = OpenEJovianDSS::Common::volume_activate( $scfg, $storeid, undef, $volname, undef, 1);
-    #
-    # my $bdpath =
-    #  $class->block_device_path( $scfg, $content_volname, $storeid, undef, 1 );
-
-    # Acquire name of block device that is mounted to content volume folder
-    my $findmntpath;
-    eval {
-        run_command(
-            [ "findmnt", $content_path, "-n", "-o", "UUID" ],
-            outfunc => sub { $findmntpath = shift; }
-        );
-    };
-
-    my $tname = $class->get_target_name( $scfg, $content_volname, undef, 1 );
-
-    # if there is a block device mounted to content volume folder
-    if ( defined($findmntpath) ) {
-        my $tuuid = undef;
-
-        # We need to check that volume mounted to content volume folder is the one
-        # specified in config. This volume might change if user decide to change content volumes
-        # of if user decide to enable multipath or disable it
-        # We want to be sure that volume representing multipath block device is mounted if multipath is enabled
-        # If that is not a proper device we better unmount and do remounting
-        foreach my $bdpath (@$block_devs) {
-            eval {
-                run_command( [ 'blkid', '-o', 'value', $bdpath, '-s', 'UUID' ],
-                    outfunc => sub { $tuuid = shift; } );
-            };
-            if ($@) {
-                $class->deactivate_storage( $storeid, $scfg, $cache );
-                last;
-            }
-            if ( defined($tuuid) ) {
-                last;
-            }
-        }
-
-        if ( $findmntpath eq $tuuid ) {
-            return 1;
-        }
-        $class->deactivate_storage( $storeid, $scfg, $cache );
-    }
-
-    my $create_vol_cmd = [
-        "pool", $pool,
-        "volumes",
-        "create", "-d", "-s", "${content_volume_size}G", '-n', $content_volname
-    ];
-
-    my $block_size = OpenEJovianDSS::Common::get_block_size($scfg);
-    my $thin_provisioning = OpenEJovianDSS::Common::get_thin_provisioning($scfg);
-
-    if (defined($thin_provisioning)) {
-        push @$create_vol_cmd, '--thin-provisioning', $thin_provisioning;
-    }
-
-    if (defined($block_size)) {
-        push @$create_vol_cmd, '--block-size', $block_size;
-    }
-
-    # TODO: check for volume size on the level of OS
-    # If volume needs resize do it with jdssc
-    my $content_volume_size_current;
-    eval {
-        $content_volume_size_current = OpenEJovianDSS::Common::joviandss_cmd(
-            $scfg,
-            [
-                "pool", $pool,
-                "volume", $content_volname, "get",  "-d", "-G"
-            ]
-        );
-    };
-    if ( ! defined($content_volume_size_current)) {
-        OpenEJovianDSS::Common::joviandss_cmd(
-            $scfg,
-            $create_vol_cmd
-        );
-    } elsif (defined($content_volume_size_current) &&
-             $content_volume_size_current =~ /^\d+$/ &&
-             $content_volume_size_current > 0 ) {
-        # TODO: check for volume size on the level of OS
-        # If volume needs resize do it with jdssc
-        $content_volume_size_current = OpenEJovianDSS::Common::clean_word($content_volume_size_current);
-        if ( $content_volume_size > $content_volume_size_current ) {
-            OpenEJovianDSS::Common::joviandss_cmd(
-                $scfg,
-                [
-                    "pool", $pool,
-                    "volume", $content_volname,
-                    "resize", "-d", "${content_volume_size}G"
-                ]
-            );
-        }
-    } else {
-        OpenEJovianDSS::Common::debugmsg( $scfg, "warning", "Unable to process current size of content volume size <${content_volume_size_current}>, please make sure that JovianDSS is accessible over network\n");
-        die "Unable to process current size of content volume size <${content_volume_size_current}>, please make sure that JovianDSS is accessible over network\n";
-    }
-
-    $class->_activate_volume( $storeid, $scfg, $content_volname, "", $cache,
-        1, undef);
-
-    eval {
-        run_command( [ "/usr/sbin/fsck", "-n", $bdpath ], outfunc => sub { } );
-    };
-    if ($@) {
-        die
-"Unable to identify file system type for content storage, if this is the first run, format ${bdpath} to the file system of your choice.\n";
-    }
-    if ( $content_volume_size > $content_volume_size_current ) {
-        eval {
-            run_command( [ "/usr/sbin/resize2fs", $bdpath ],
-                outfunc => sub { } );
-        };
-        if ($@) {
-            warn "Unable to resize content storage file system $@\n";
-        }
-    }
-    mkdir "$content_path";
-
-    my $already_mounted = 0;
-    my $mount_error     = undef;
-    my $errfunc         = sub {
-        my $line = shift;
-        if ( $line =~ /already mounted on/ ) {
-            $already_mounted = 1;
-        }
-        $mount_error .= "$line\n";
-    };
-    run_command(
-        [ "/usr/bin/mount", $bdpath, $content_path ],
-        outfunc => sub { },
-        errfunc => $errfunc,
-        timeout => 10,
-        noerr   => 1
-    );
-    if ( $mount_error && !$already_mounted ) {
-        $class->deactivate_storage( $storeid, $scfg, $cache );
-        die $mount_error;
-    }
-    $class->ensure_fs($scfg);
-}
+#sub ensure_content_volume {
+#    my ( $class, $storeid, $scfg, $cache ) = @_;
+#
+#    my $content_path = OpenEJovianDSS::Common::get_content_path($scfg);
+#
+#    unless ( defined($content_path) ) {
+#        return undef;
+#    }
+#
+#    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+#
+#    my $content_volname     = OpenEJovianDSS::Common::get_content_volume_name($scfg);
+#    my $content_volume_size = OpenEJovianDSS::Common::get_content_volume_size($scfg);
+#
+#    # First we get expected path of block device representing content volume
+#    # Block Device Path
+#    my $til = OpenEJovianDSS::Common::lun_record_local_get_info_list( $scfg, $storeid, $source_volname, undef );
+#
+#    if ( @$til == 1) {
+#
+#        ($targetname, $lunid, $lunrecpath, $lr) = $til->[0];
+#    }
+#    #
+#    my $block_devs = OpenEJovianDSS::Common::volume_activate( $scfg, $storeid, undef, $volname, undef, 1);
+#    #
+#    # my $bdpath =
+#    #  $class->block_device_path( $scfg, $content_volname, $storeid, undef, 1 );
+#
+#    # Acquire name of block device that is mounted to content volume folder
+#    my $findmntpath;
+#    eval {
+#        run_command(
+#            [ "findmnt", $content_path, "-n", "-o", "UUID" ],
+#            outfunc => sub { $findmntpath = shift; }
+#        );
+#    };
+#
+#    my $tname = $class->get_target_name( $scfg, $content_volname, undef, 1 );
+#
+#    # if there is a block device mounted to content volume folder
+#    if ( defined($findmntpath) ) {
+#        my $tuuid = undef;
+#
+#        # We need to check that volume mounted to content volume folder is the one
+#        # specified in config. This volume might change if user decide to change content volumes
+#        # of if user decide to enable multipath or disable it
+#        # We want to be sure that volume representing multipath block device is mounted if multipath is enabled
+#        # If that is not a proper device we better unmount and do remounting
+#        foreach my $bdpath (@$block_devs) {
+#            eval {
+#                run_command( [ 'blkid', '-o', 'value', $bdpath, '-s', 'UUID' ],
+#                    outfunc => sub { $tuuid = shift; } );
+#            };
+#            if ($@) {
+#                $class->deactivate_storage( $storeid, $scfg, $cache );
+#                last;
+#            }
+#            if ( defined($tuuid) ) {
+#                last;
+#            }
+#        }
+#
+#        if ( $findmntpath eq $tuuid ) {
+#            return 1;
+#        }
+#        $class->deactivate_storage( $storeid, $scfg, $cache );
+#    }
+#
+#    my $create_vol_cmd = [
+#        "pool", $pool,
+#        "volumes",
+#        "create", "-d", "-s", "${content_volume_size}G", '-n', $content_volname
+#    ];
+#
+#    my $block_size = OpenEJovianDSS::Common::get_block_size($scfg);
+#    my $thin_provisioning = OpenEJovianDSS::Common::get_thin_provisioning($scfg);
+#
+#    if (defined($thin_provisioning)) {
+#        push @$create_vol_cmd, '--thin-provisioning', $thin_provisioning;
+#    }
+#
+#    if (defined($block_size)) {
+#        push @$create_vol_cmd, '--block-size', $block_size;
+#    }
+#
+#    # TODO: check for volume size on the level of OS
+#    # If volume needs resize do it with jdssc
+#    my $content_volume_size_current;
+#    eval {
+#        $content_volume_size_current = OpenEJovianDSS::Common::joviandss_cmd(
+#            $scfg,
+#            [
+#                "pool", $pool,
+#                "volume", $content_volname, "get",  "-d", "-G"
+#            ]
+#        );
+#    };
+#    if ( ! defined($content_volume_size_current)) {
+#        OpenEJovianDSS::Common::joviandss_cmd(
+#            $scfg,
+#            $create_vol_cmd
+#        );
+#    } elsif (defined($content_volume_size_current) &&
+#             $content_volume_size_current =~ /^\d+$/ &&
+#             $content_volume_size_current > 0 ) {
+#        # TODO: check for volume size on the level of OS
+#        # If volume needs resize do it with jdssc
+#        $content_volume_size_current = OpenEJovianDSS::Common::clean_word($content_volume_size_current);
+#        if ( $content_volume_size > $content_volume_size_current ) {
+#            OpenEJovianDSS::Common::joviandss_cmd(
+#                $scfg,
+#                [
+#                    "pool", $pool,
+#                    "volume", $content_volname,
+#                    "resize", "-d", "${content_volume_size}G"
+#                ]
+#            );
+#        }
+#    } else {
+#        OpenEJovianDSS::Common::debugmsg( $scfg, "warning", "Unable to process current size of content volume size <${content_volume_size_current}>, please make sure that JovianDSS is accessible over network\n");
+#        die "Unable to process current size of content volume size <${content_volume_size_current}>, please make sure that JovianDSS is accessible over network\n";
+#    }
+#
+#    $class->_activate_volume( $storeid, $scfg, $content_volname, "", $cache,
+#        1, undef);
+#
+#    eval {
+#        run_command( [ "/usr/sbin/fsck", "-n", $bdpath ], outfunc => sub { } );
+#    };
+#    if ($@) {
+#        die
+#"Unable to identify file system type for content storage, if this is the first run, format ${bdpath} to the file system of your choice.\n";
+#    }
+#    if ( $content_volume_size > $content_volume_size_current ) {
+#        eval {
+#            run_command( [ "/usr/sbin/resize2fs", $bdpath ],
+#                outfunc => sub { } );
+#        };
+#        if ($@) {
+#            warn "Unable to resize content storage file system $@\n";
+#        }
+#    }
+#    mkdir "$content_path";
+#
+#    my $already_mounted = 0;
+#    my $mount_error     = undef;
+#    my $errfunc         = sub {
+#        my $line = shift;
+#        if ( $line =~ /already mounted on/ ) {
+#            $already_mounted = 1;
+#        }
+#        $mount_error .= "$line\n";
+#    };
+#    run_command(
+#        [ "/usr/bin/mount", $bdpath, $content_path ],
+#        outfunc => sub { },
+#        errfunc => $errfunc,
+#        timeout => 10,
+#        noerr   => 1
+#    );
+#    if ( $mount_error && !$already_mounted ) {
+#        $class->deactivate_storage( $storeid, $scfg, $cache );
+#        die $mount_error;
+#    }
+#    $class->ensure_fs($scfg);
+#}
 
 sub ensure_fs {
     my ( $class, $scfg ) = @_;
@@ -1414,7 +1379,7 @@ sub ensure_fs {
 sub activate_storage {
     my ( $class, $storeid, $scfg, $cache ) = @_;
     OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
-            "Activate storage ${storeid}\n");
+        "Activate storage ${storeid}\n" );
 
     return undef if !defined( $scfg->{content} );
 
@@ -1424,9 +1389,11 @@ sub activate_storage {
 
     my $content_volume_needed = 0;
     foreach my $content_type (@content_types) {
-        OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Checking content type $content_type\n");
+        OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+            "Checking content type $content_type\n" );
         if ( exists $enabled_content->{$content_type} ) {
-            OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Set content volume flag\n");
+            OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+                "Set content volume flag\n" );
             $content_volume_needed = 1;
             last;
         }
@@ -1434,14 +1401,16 @@ sub activate_storage {
 
     if ($content_volume_needed) {
         my $cvt = OpenEJovianDSS::Common::get_content_volume_type($scfg);
-        OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Content volume type ${cvt}\n");
+        OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+            "Content volume type ${cvt}\n" );
 
         if ( $cvt eq "nfs" ) {
             $class->ensure_content_volume_nfs( $storeid, $scfg, $cache );
         }
-        else {
-            $class->ensure_content_volume( $storeid, $scfg, $cache );
-        }
+
+        #else {
+        #    $class->ensure_content_volume( $storeid, $scfg, $cache );
+        #}
     }
     return undef;
 }
@@ -1449,12 +1418,14 @@ sub activate_storage {
 sub deactivate_storage {
     my ( $class, $storeid, $scfg, $cache ) = @_;
 
-    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Deactivating storage ${storeid}\n");
+    OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
+        "Deactivating storage ${storeid}\n" );
 
     my $path = OpenEJovianDSS::Common::get_content_path($scfg);
     my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
-    my $content_volname = OpenEJovianDSS::Common::get_content_volume_name($scfg);
+    my $content_volname =
+      OpenEJovianDSS::Common::get_content_volume_name($scfg);
     my $target;
 
 # TODO: consider removing multipath and iscsi target on the basis of mount point
@@ -1469,25 +1440,25 @@ sub deactivate_storage {
         }
     }
 
-    return unless defined($content_volname);
+    #return unless defined($content_volname);
 
-    $target = OpenEJovianDSS::Common::get_active_target_name(
-        scfg    => $scfg,
-        volname => $content_volname,
-        content => 1
-    );
-    unless ( defined($target) ) {
-        $target = $class->get_target_name( $scfg, $content_volname, undef, 1 );
-    }
+    #$target = OpenEJovianDSS::Common::get_active_target_name(
+    #    scfg    => $scfg,
+    #    volname => $content_volname,
+    #    content => 1
+    #);
+    #unless ( defined($target) ) {
+    #    $target = $class->get_target_name( $scfg, $content_volname, undef, 1 );
+    #}
 
-    if ( OpenEJovianDSS::Common::get_multipath($scfg) ) {
-        OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Removing multipath\n");
-        $class->unstage_multipath( $scfg, $storeid, $target );
-    }
-    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Unstaging target\n");
-    $class->unstage_target( $scfg, $storeid, $target );
+ #if ( OpenEJovianDSS::Common::get_multipath($scfg) ) {
+ #    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Removing multipath\n");
+ #    $class->unstage_multipath( $scfg, $storeid, $target );
+ #}
+ #OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Unstaging target\n");
+ #$class->unstage_target( $scfg, $storeid, $target );
 
-    return undef;
+    #return undef;
 }
 
 sub activate_volume {
@@ -1502,7 +1473,21 @@ sub activate_volume {
 
     return 0 if ( 'images' ne "$vtype" );
 
-    OpenEJovianDSS::Common::volume_activate( $scfg, $storeid, $vmid, $volname, $snapname, undef);
+    my $til =
+      OpenEJovianDSS::Common::lun_record_local_get_info_list( $scfg, $storeid,
+        $volname, $snapname );
+
+    unless (@$til) {
+        OpenEJovianDSS::Common::volume_activate( $scfg, $storeid, $vmid,
+            $volname, $snapname, undef );
+    }
+    else {
+        # If volume was resized on other node we have to make sure that current size is accurate
+        my $current_size = OpenEJovianDSS::Common::volume_get_size( $scfg, $storeid, $volname);
+        my ( $targetname, $lunid, $lunrecpath, $lr ) = $til->[0];
+        if ($current_size > $lr->{size} ) {
+           OpenEJovianDSS::Common::volume_update_size()
+    }
 
     OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
             "Activate volume ${volname}"
@@ -1520,12 +1505,30 @@ sub deactivate_volume {
           . OpenEJovianDSS::Common::safe_var_print( "snapshot", $snapname )
           . "start" );
     my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $prefix = OpenEJovianDSS::Common::get_target_prefix($scfg);
 
     my ( $vtype, $name, $vmid ) = $class->parse_volname($volname);
 
     return 0 if ( 'images' ne "$vtype" );
 
-    OpenEJovianDSS::Common::volume_deactivate( $scfg, $storeid, $vmid, $volname, $snapname, undef );
+    unless ( defined($snapname) ) {
+        my $delitablesnaps = OpenEJovianDSS::Common::joviandss_cmd(
+            $scfg,
+            [
+                "pool",   $pool, "volume", $volname,
+                "delete", "-c",  "-p",     '--target-prefix',
+                $prefix
+            ]
+        );
+        my @dsl = split( " ", $delitablesnaps );
+
+        foreach my $snap (@dsl) {
+            OpenEJovianDSS::Common::volume_deactivate( $scfg, $storeid, $vmid,
+                $volname, $snap, undef );
+        }
+    }
+    OpenEJovianDSS::Common::volume_deactivate( $scfg, $storeid, $vmid,
+        $volname, $snapname, undef );
 
     OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
             "Deactivate volume "
@@ -1538,20 +1541,20 @@ sub deactivate_volume {
 sub volume_resize {
     my ( $class, $scfg, $storeid, $volname, $size, $running ) = @_;
 
-    my $pool   = OpenEJovianDSS::Common::get_pool($scfg);
+    my $pool = OpenEJovianDSS::Common::get_pool($scfg);
 
     OpenEJovianDSS::Common::debugmsg( $scfg, "debug",
         "Resize volume ${volname} to size ${size}" );
 
-    OpenEJovianDSS::Common::joviandss_cmd(
-        $scfg,
-        [
-            "pool",   "${pool}",
-            "volume", "${volname}",
-            "resize", "${size}"
-        ]
-    );
-    OpenEJovianDSS::Common::volume_update( $scfg, $storeid, $volname, $size );
+    OpenEJovianDSS::Common::joviandss_cmd( $scfg,
+            [ "pool", "${pool}", "volume", "${volname}", "resize", "${size}" ] );
+
+    my $til = OpenEJovianDSS::Common::lun_record_local_get_info_list( $scfg,
+            $storeid, $volname, $snapname );
+    if ( @$til == 1 ) {
+        my ( $targetname, $lunid, $lunrecpath, $lr ) = $til->[0];
+        lun_record_update_device( $scfg, $storeid, $targetname, $lunid, $lunrecpath, $lunrecord, $size);
+    }
 
     return 1;
 }
@@ -1621,34 +1624,34 @@ sub volume_has_feature {
     ) = @_;
 
     my $features = {
-        snapshot   => {
+        snapshot => {
             base    => 1,
             current => 1,
-            snap => 1
+            snap    => 1
         },
-        clone      => {
+        clone => {
             base    => 1,
             current => 1,
-            snap => 1,
-            images => 1
+            snap    => 1,
+            images  => 1
         },
-        template   => {
+        template => {
             current => 1
         },
-        copy       => {
+        copy => {
             base    => 1,
             current => 1,
-            snap => 1
+            snap    => 1
         },
         sparseinit => {
-            base    => {
+            base => {
                 raw => 1
             },
             current => {
                 raw => 1
             }
         },
-        rename     => {
+        rename => {
             current => {
                 raw => 1
             },

--- a/OpenEJovianDSSPlugin.pm
+++ b/OpenEJovianDSSPlugin.pm
@@ -77,9 +77,12 @@ my $PLUGIN_VERSION = '0.10.0-0';
 #    0.9.10-8 - 2025.04.02
 #               Make plugin configurable solely by from storage.cfg
 #               Provide code style improvement
+#
 #    0.10.0-0 - 2025.06.17
 #               Storing information about activated volumes and snapshots
 #               localy
+#               Support proxmox API v11
+#               Major code rework
 
 # Configuration
 

--- a/OpenEJovianDSSPlugin.pm
+++ b/OpenEJovianDSSPlugin.pm
@@ -262,7 +262,7 @@ sub path {
             print("Block device path after activation $pathval\n");
             $pathval =~ m{^([\:\w\-/\.]+)$}
               or die "Invalid source path '$pathval'";
-            return $pathval;
+            return wantarray ? ( $pathval, $vmid, $vtype ) : $pathval;
         }
 
         if ( @$til == 1 ) {
@@ -273,7 +273,7 @@ sub path {
             print("Block device path $pathval\n");
             $pathval =~ m{^([\:\w\-/\.]+)$}
               or die "Invalid source path '$pathval'";
-            return $pathval;
+            return wantarray ? ( $pathval, $vmid, $vtype ) : $pathval;
         }
 
         die "Resource ${volname}"
@@ -1010,9 +1010,9 @@ sub volume_resize {
       OpenEJovianDSS::Common::lun_record_local_get_info_list( $scfg, $storeid,
         $volname, undef );
     if ( @$til == 1 ) {
-        my ( $targetname, $lunid, $lunrecpath, $lunrecord ) = $til->[0];
-        lun_record_update_device( $scfg, $storeid, $targetname, $lunid,
-            $lunrecpath, $lunrecord, $size );
+        my ( $targetname, $lunid, $lunrecpath, $lunrecord ) = @{ $til->[0] };
+        OpenEJovianDSS::Common::lun_record_update_device( $scfg, $storeid,
+            $targetname, $lunid, $lunrecpath, $lunrecord, $size );
     }
 
     return 1;

--- a/OpenEJovianDSSPlugin.pm
+++ b/OpenEJovianDSSPlugin.pm
@@ -226,9 +226,6 @@ sub options {
 my $ISCSIADM = '/usr/bin/iscsiadm';
 $ISCSIADM = undef if !-X $ISCSIADM;
 
-my $MULTIPATH = '/usr/sbin/multipath';
-$MULTIPATH = undef if !-X $MULTIPATH;
-
 my $SYSTEMCTL = '/usr/bin/systemctl';
 $SYSTEMCTL = undef if !-X $SYSTEMCTL;
 
@@ -245,8 +242,6 @@ sub path {
         my $til = OpenEJovianDSS::Common::lun_record_local_get_info_list( $scfg,
             $storeid, $volname, $snapname );
 
-        #print( Dumper($til) );
-
         unless (@$til) {
             my $bdpl =
               OpenEJovianDSS::Common::volume_activate( $scfg, $storeid, $vmid,
@@ -259,7 +254,6 @@ sub path {
                   . "\n";
             }
             my $pathval = ${$bdpl}[0];
-            print("Block device path after activation $pathval\n");
             $pathval =~ m{^([\:\w\-/\.]+)$}
               or die "Invalid source path '$pathval'";
             return wantarray ? ( $pathval, $vmid, $vtype ) : $pathval;
@@ -270,7 +264,6 @@ sub path {
             my $pathval =
               OpenEJovianDSS::Common::block_device_path_from_lun_rec( $scfg,
                 $storeid, $targetname, $lunid, $lr );
-            print("Block device path $pathval\n");
             $pathval =~ m{^([\:\w\-/\.]+)$}
               or die "Invalid source path '$pathval'";
             return wantarray ? ( $pathval, $vmid, $vtype ) : $pathval;

--- a/OpenEJovianDSSPluginLVM.pm
+++ b/OpenEJovianDSSPluginLVM.pm
@@ -651,7 +651,7 @@ sub vm_disk_extend_to {
 
     OpenEJovianDSS::Common::joviandss_cmd($scfg, ["pool", "${pool}", "volume", "${vmdiskname}", "resize", "${newsize}"]);
 
-    $class->vm_disk_lvm_update($storeid, $scfg, $vmdiskname, $device, $newsize);
+    # $class->vm_disk_lvm_update($storeid, $scfg, $vmdiskname, $device, $newsize);
 
     return ;
 }
@@ -1578,15 +1578,19 @@ sub volume_resize {
     my $vmdiskname = $class->vm_disk_name($vmid, 0);
     my $vmvgname = $class->vm_vg_name($vmid);
 
-    my $device = $class->vm_disk_connect($storeid, $scfg, $vmdiskname, undef, undef);
+    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "Resize volume ${volname} to ${size}\n");
 
-    OpenEJovianDSS::Common::debugmsg( $scfg, "debug", "VM disk ${vmdiskname} is connected to ${device}\n");
+    my $block_devs = OpenEJovianDSS::Common::activate_volume( $storeid, $scfg, $vmdiskname, undef, undef);
 
-    my $vginfo = vm_disk_vg_info($device, $vmvgname);
+    my $vginfo;
+    my $device;
+    if ( @$block_devs ) {
+        $device = $block_dev;
+    }
+    $vginfo = vm_disk_vg_info($block_devs->[0], $vmvgname);
 
     # get zvol size
     my $vmdisksize = $class->vm_disk_size($scfg, $vmdiskname);
-
 
     # check if zvol size is not different from LVM size
     # that should handle cases of failure during volume resizing

--- a/OpenEJovianDSSPluginLVM.pm
+++ b/OpenEJovianDSSPluginLVM.pm
@@ -1585,7 +1585,7 @@ sub volume_resize {
     my $vginfo;
     my $device;
     if ( @$block_devs ) {
-        $device = $block_dev;
+        $device = ${ $block_devs }[0];
     }
     $vginfo = vm_disk_vg_info($block_devs->[0], $vmvgname);
 

--- a/blockdevicemanager/blockdevicemanager
+++ b/blockdevicemanager/blockdevicemanager
@@ -1,0 +1,316 @@
+#!/usr/bin/python3
+
+#    Copyright (c) 2025 Open-E, Inc.
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+import shutil
+import subprocess
+import logging
+import socket
+import select
+
+import toml
+from inotify_simple import INotify, flags
+
+PVE_BASE = '/etc/pve/priv/joviandss'
+LOCAL_BASE = '/etc/joviandss'
+SOCKET_PATH = '/var/run/joviandssblockdevicemanager.sock'
+
+
+def setup_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s: %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+
+load = toml.load
+
+
+def iscsi_login(target, addresses, port):
+    for addr in addresses:
+        cmd = ['iscsiadm',
+               '-m', 'node',
+               '-T', target,
+               '-p', f"{addr}:{port}",
+               '--login']
+        logging.info(f"Logging in target {target} at {addr}:{port}")
+        subprocess.run(cmd, check=False)
+
+
+def iscsi_logout(target, addresses, port):
+    for addr in addresses:
+        cmd = ['iscsiadm',
+               '-m', 'node',
+               '-T', target,
+               '-p', f"{addr}:{port}",
+               '--logout']
+        logging.info(f"Logging out target {target} at {addr}:{port}")
+        subprocess.run(cmd, check=False)
+
+
+def rescan_iscsi():
+    cmd = ['iscsiadm',
+           '-m', 'node',
+           '--rescan']
+    logging.info("Rescanning iSCSI sessions")
+    subprocess.run(cmd, check=False)
+
+
+def multipath_add(iscsiid):
+    cmd = ['multipath', '-a', iscsiid]
+    logging.info(f"Adding multipath for {iscsiid}")
+    subprocess.run(cmd, check=False)
+
+
+def multipath_remove(iscsiid):
+    logging.info(f"Removing multipath for {iscsiid}")
+    # Attempt graceful multipath removal
+    result = subprocess.run(['multipath', '-f', iscsiid],
+                            capture_output=True,
+                            text=True)
+    if result.returncode != 0:
+        logging.warning(
+            f"Multipath -f failed for {iscsiid}: {result.stderr.strip()}")
+        # Fallback: remove underlying device mapper entries
+        mp_ll = subprocess.run(['multipath', '-ll', iscsiid],
+                               capture_output=True,
+                               text=True)
+        if mp_ll.returncode == 0:
+            for line in mp_ll.stdout.splitlines():
+                m = re.match(r'^(\S+)\s+\(', line)
+                if m:
+                    dm_name = m.group(1)
+                    logging.info(f"Removing dmsetup entry {dm_name}")
+                    subprocess.run(['dmsetup', 'remove', '-f', dm_name],
+                                   check=False)
+        else:
+            logging.error(f"Failed to list multipath maps for {
+                          iscsiid}: {mp_ll.stderr.strip()}")
+
+
+def load_hosts(store_dir):
+    data = load(os.path.join(store_dir, 'hosts'))
+    return data.get('addresses', []), data.get('port')
+
+
+def load_lun(lun_path):
+    data = load(lun_path)
+    return data['iscsiid'], data['name'], data['size'], data['multipath']
+
+
+def sync():
+    # Enumerate storeid directories
+    pve_storeids = {d for d in os.listdir(
+        PVE_BASE) if os.path.isdir(os.path.join(PVE_BASE, d))}
+    local_storeids = {d for d in os.listdir(
+        LOCAL_BASE) if os.path.isdir(os.path.join(LOCAL_BASE, d))}
+
+    # New storeids
+    for sid in pve_storeids - local_storeids:
+        local_dir = os.path.join(LOCAL_BASE, sid)
+        logging.info(f"New storeid detected: {sid}")
+        os.makedirs(local_dir, exist_ok=True)
+
+    # Removed storeids: cleanup all targets & luns
+    for sid in local_storeids - pve_storeids:
+        sid_dir = os.path.join(LOCAL_BASE, sid)
+        logging.info(f"Storeid removed: {
+                     sid}, cleaning up all targets and LUNs")
+        # Iterate each target under this storeid
+        for tgt in os.listdir(sid_dir):
+            tgt_dir = os.path.join(sid_dir, tgt)
+            if not os.path.isdir(tgt_dir):
+                continue
+            # Load hosts to logout
+            addresses, port = load_hosts(tgt_dir)
+            # Remove all LUN multipaths and files
+            for lun in os.listdir(tgt_dir):
+                if lun == 'hosts':
+                    continue
+                lun_path = os.path.join(tgt_dir, lun)
+                iscsiid, _, _, mp = load_lun(lun_path)
+                if mp:
+                    multipath_remove(iscsiid)
+                os.remove(lun_path)
+            # Logout target
+            iscsi_logout(tgt, addresses, port)
+            # Remove target directory
+            shutil.rmtree(tgt_dir)
+        # Finally, remove storeid directory
+        shutil.rmtree(sid_dir)
+
+    # Sync per-storeid targets & LUNs
+    for sid in pve_storeids & local_storeids:
+        pve_sid_dir = os.path.join(PVE_BASE, sid)
+        local_sid_dir = os.path.join(LOCAL_BASE, sid)
+
+        pve_targets = {d for d in os.listdir(
+            pve_sid_dir) if os.path.isdir(os.path.join(pve_sid_dir, d))}
+        local_targets = {d for d in os.listdir(
+            local_sid_dir) if os.path.isdir(os.path.join(local_sid_dir, d))}
+
+        # New targets
+        for tgt in pve_targets - local_targets:
+            pve_dir = os.path.join(pve_sid_dir, tgt)
+            local_dir = os.path.join(local_sid_dir, tgt)
+            addresses, port = load_hosts(pve_dir)
+            logging.info(f"[{sid}] New target detected: {tgt}")
+            iscsi_login(tgt, addresses, port)
+            os.makedirs(local_dir, exist_ok=True)
+            shutil.copy(os.path.join(pve_dir, 'hosts'),
+                        os.path.join(local_dir, 'hosts'))
+
+        # Existing targets: handle LUNs
+        for tgt in pve_targets & local_targets:
+            pve_dir = os.path.join(pve_sid_dir, tgt)
+            local_dir = os.path.join(local_sid_dir, tgt)
+            addresses, port = load_hosts(pve_dir)
+
+            pve_luns = {f for f in os.listdir(pve_dir) if f != 'hosts'}
+            local_luns = {f for f in os.listdir(local_dir) if f != 'hosts'}
+
+            # New LUNs
+            for lun in pve_luns - local_luns:
+                pve_lun = os.path.join(pve_dir, lun)
+                logging.info(f"[{sid}/{tgt}] New LUN {lun}")
+                iscsi_login(tgt, addresses, port)
+                rescan_iscsi()
+                iscsiid, _, _, mp = load_lun(pve_lun)
+                if mp:
+                    multipath_add(iscsiid)
+                shutil.copy(pve_lun, os.path.join(local_dir, lun))
+
+            # Removed LUNs
+            for lun in local_luns - pve_luns:
+                local_lun = os.path.join(local_dir, lun)
+                logging.info(f"[{sid}/{tgt}] Removed LUN {lun}")
+                iscsiid, _, _, mp = load_lun(local_lun)
+                if mp:
+                    multipath_remove(iscsiid)
+                os.remove(local_lun)
+
+            # If no more LUNs, logout and remove target
+            if not pve_luns:
+                logging.info(f"[{sid}/{tgt}] No more LUNs, "
+                             "logging out and removing target")
+                iscsi_logout(tgt, addresses, port)
+                shutil.rmtree(local_dir)
+
+        # Removed targets
+        for tgt in local_targets - pve_targets:
+            local_dir = os.path.join(local_sid_dir, tgt)
+            addresses, port = load_hosts(local_dir)
+            logging.info(f"[{sid}] Target {
+                         tgt} removed, logging out and cleaning up")
+            iscsi_logout(tgt, addresses, port)
+            shutil.rmtree(local_dir)
+
+
+def setup_socket():
+    if os.path.exists(SOCKET_PATH):
+        os.remove(SOCKET_PATH)
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(SOCKET_PATH)
+    os.chmod(SOCKET_PATH, 0o660)
+    server.listen(1)
+    server.setblocking(False)
+    logging.info(f"Listening for sync commands on {SOCKET_PATH}")
+    return server
+
+
+def main():
+    setup_logging()
+    logging.info("Starting joviandss daemon")
+    os.makedirs(LOCAL_BASE, exist_ok=True)
+
+    # Inotify setup
+    inotify = INotify()
+    watch_flags = flags.CREATE | flags.DELETE | flags.MOVED_TO | flags.MOVED_FROM
+    wd_map = {}
+
+    def add_watch(path):
+        try:
+            wd = inotify.add_watch(path, watch_flags)
+            wd_map[wd] = path
+            logging.info(f"Watching {path}")
+        except Exception as e:
+            logging.error(f"Failed to watch {path}: {e}")
+
+    # Watch base and existing subdirs
+    add_watch(PVE_BASE)
+    for sid in os.listdir(PVE_BASE):
+        sid_path = os.path.join(PVE_BASE, sid)
+        if os.path.isdir(sid_path):
+            add_watch(sid_path)
+            for tgt in os.listdir(sid_path):
+                tgt_path = os.path.join(sid_path, tgt)
+                if os.path.isdir(tgt_path):
+                    add_watch(tgt_path)
+
+    # Socket
+    server = setup_socket()
+
+    # Initial sync
+    sync()
+
+    try:
+        while True:
+            fds = [inotify.fd, server.fileno()]
+            r, _, _ = select.select(fds, [], [], 5)
+            sync_needed = False
+
+            for fd in r:
+                if fd == inotify.fd:
+                    events = inotify.read(read_delay=0)
+                    sync_needed = True
+                    for event in events:
+                        path = wd_map.get(event.wd)
+                        name = event.name
+                        full = os.path.join(path, name) if name else path
+                        if path == PVE_BASE and (event.mask & flags.CREATE):
+                            if os.path.isdir(full):
+                                add_watch(full)
+                        elif (os.path.dirname(path) == PVE_BASE and
+                                (event.mask & flags.CREATE)):
+                            if os.path.isdir(full):
+                                add_watch(full)
+                elif fd == server.fileno():
+                    conn, _ = server.accept()
+                    data = conn.recv(1024)
+                    if data.strip() == b'SYNC':
+                        logging.info("Received external SYNC command")
+                        sync_needed = True
+                    conn.close()
+
+            if sync_needed:
+                try:
+                    sync()
+                except Exception as e:
+                    logging.error(f"Error during sync: {e}")
+
+    except KeyboardInterrupt:
+        logging.info("Stopping joviandss daemon")
+    finally:
+        inotify.close()
+        server.close()
+        if os.path.exists(SOCKET_PATH):
+            os.remove(SOCKET_PATH)
+
+
+if __name__ == '__main__':
+    main()

--- a/blockdevicemanager/joviandssblockdevicemanager.service
+++ b/blockdevicemanager/joviandssblockdevicemanager.service
@@ -1,0 +1,12 @@
+# /etc/systemd/system/joviandssblockdevicemanager.service
+[Unit]
+Description=JovianDSS iSCSI Sync Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/joviandssblockdevicemanager
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/jdssc/jdssc/jovian_common/driver.py
+++ b/jdssc/jdssc/jovian_common/driver.py
@@ -1286,6 +1286,11 @@ class JovianDSSDriver(object):
 
         return target_names
 
+    def list_target_luns(self, target):
+        luns = self.ra.get_target_luns(target)
+
+        return luns
+
     def _attach_target_volume_lun(self, target_name, vname, lun):
         """Attach target to volume and handles exceptions
 

--- a/jdssc/jdssc/snapshot.py
+++ b/jdssc/jdssc/snapshot.py
@@ -58,7 +58,16 @@ class Snapshot():
 
         parser.add_argument('snapshot_name', help='Snapshot name')
         parsers = parser.add_subparsers(dest='snapshot_action')
-        parsers.add_parser('delete')
+        delete = parsers.add_parser('delete')
+        delete.add_argument('--target-prefix',
+                            dest='target_prefix',
+                            default=None,
+                            help='''
+                            Pattern for target name prefix.
+                            User can specify plain text or template
+                            in python strftime format.
+                            Default is "iqn.2025-04.iscsi:"
+                            ''')
         parsers.add_parser('rollback')
 
         kargs, ukargs = parser.parse_known_args(args)
@@ -72,6 +81,8 @@ class Snapshot():
     def delete(self):
 
         try:
+            if self.args['target_prefix']:
+                self.jdss.set_target_prefix(self.args['target_prefix'])
             self.jdss.delete_snapshot(self.args['volume_name'],
                                       self.args['snapshot_name'])
         except jexc.JDSSSnapshotIsBusyException:

--- a/jdssc/jdssc/targets.py
+++ b/jdssc/jdssc/targets.py
@@ -208,7 +208,7 @@ class Targets():
         out = ('%(target)s %(lun)d %(hosts)s' % {
             'target': tinfo['target'],
             'lun': tinfo['lun'],
-            'hosts': tinfo['hosts']})
+            'hosts': ','.join(tinfo['vips'])})
         print(out)
 
     def delete(self):

--- a/jdssc/jdssc/targets.py
+++ b/jdssc/jdssc/targets.py
@@ -63,11 +63,19 @@ class Targets():
         create.add_argument('--target-prefix',
                             dest='target_prefix',
                             default=None,
+                            required=True,
                             help='''
                             Pattern for target name prefix.
                             User can specify plain text or template
                             in python strftime format.
-                            Default is "iqn.%%Y-%%m.iscsi:"
+                            ''')
+        create.add_argument('--target-group-name',
+                            dest='target_group_name',
+                            required=True,
+                            default=None,
+                            help='''
+                            Target name.
+                            It will be added to target prefix"
                             ''')
         create.add_argument('--snapshot',
                             dest='snapshot_name', default=None,
@@ -87,7 +95,7 @@ class Targets():
                             Pattern for target name prefix.
                             User can specify plain text or template
                             in python strftime format.
-                            Default is "iqn.%%Y-%%m.iscsi:"
+                            Default is "iqn.2025-04.iscsi:"
                             ''')
         delete.add_argument('-v',
                             required=True,
@@ -111,17 +119,22 @@ class Targets():
                          Pattern for target name prefix.
                          User can specify plain text or template
                          in python strftime format.
-                         Default is "iqn.%%Y-%%m.iscsi:"
+                         Default is "iqn.2025-04.iscsi:"
                          ''')
-        get.add_argument('--path', dest='path_format', action='store_true',
-                         default=False,
-                         help='Print in path format')
-        get.add_argument('--host', action='store_true',
-                         default=False,
-                         help='Print host address')
-        get.add_argument('--lun', action='store_true',
-                         default=False,
-                         help='Print lun')
+        get.add_argument('--target-group-name',
+                         dest='target_group_name',
+                         required=True,
+                         default=None,
+                         help='''
+                            Target name.
+                            It will be added to target prefix"
+                            ''')
+        get.add_argument('-v',
+                         required=True,
+                         dest='volume_name',
+                         default=None,
+                         type=str,
+                         help='New volume name')
         get.add_argument('--snapshot', dest='snapshot_name',
                          # It is important to make default snapshot None
                          # as it is used later to acquire target name
@@ -144,12 +157,6 @@ class Targets():
                          action='store_true',
                          default=False,
                          help='Use real volume name')
-        get.add_argument('-v',
-                         required=True,
-                         dest='volume_name',
-                         default=None,
-                         type=str,
-                         help='New volume name')
 
         parsers.add_parser('list')
 
@@ -162,29 +169,28 @@ class Targets():
         return kargs, ukargs
 
     def create(self):
-        provider_location = None
+        tinfo = None
 
-        if self.args['target_prefix']:
-            self.jdss.set_target_prefix(self.args['target_prefix'])
+        self.jdss.set_target_prefix(self.args['target_prefix'])
+
+        target_prefix = self.args['target_prefix']
+
+        target_group_name = self.args['target_group_name']
 
         try:
             if self.args['snapshot_name']:
 
-                self.jdss.create_export_snapshot(
+                tinfo = self.jdss.create_export_snapshot(
                     self.args['snapshot_name'],
                     self.args['volume_name'],
                     None)
-                provider_location = self.jdss.get_provider_location(
-                    self.args['volume_name'],
-                    snapshot_name=self.args['snapshot_name'])
-
             else:
-                self.jdss.ensure_export(
+                tinfo = self.jdss.ensure_target_volume(
+                    target_prefix,
+                    target_group_name,
                     self.args['volume_name'],
                     None,
                     direct_mode=self.args['direct_mode'])
-                provider_location = self.jdss.get_provider_location(
-                    self.args['volume_name'])
         except jexc.JDSSVIPNotFoundException as jerr:
             LOG.error(
                 "%s. Please make sure that VIP are assigned to the Pool",
@@ -198,12 +204,11 @@ class Targets():
         except jexc.JDSSException as jgerr:
             LOG.error(jgerr.message)
             exit(1)
-        out = ''
-        if self.args['host']:
-            out += ' ' + ':'.join(provider_location.split()[0].split(':')[:-1])
-        if self.args['lun']:
-            out += ' ' + provider_location.split()[2]
-        out = provider_location.split()[1] + out
+
+        out = ('%(target)s %(lun)d %(hosts)s' % {
+            'target': tinfo['target'],
+            'lun': tinfo['lun'],
+            'hosts': tinfo['hosts']})
         print(out)
 
     def delete(self):
@@ -228,13 +233,15 @@ class Targets():
 
         LOG.debug("Getting target for volume %s", self.args['volume_name'])
 
-        target = None
+        tinfo = None
 
         if self.args['current']:
             LOG.debug("Getting current target")
 
             try:
-                target = self.jdss.get_volume_target(
+                tinfo = self.jdss.get_volume_target(
+                    self.args['target_prefix'],
+                    self.args['target_group_name'],
                     self.args['volume_name'],
                     snapshot_name=self.args['snapshot_name'],
                     direct=self.args['direct_mode'])
@@ -243,54 +250,16 @@ class Targets():
             except jexc.JDSSException as jgerr:
                 LOG.error(jgerr.message)
                 exit(1)
-        LOG.debug("target is %s", target)
+        if tinfo is None:
+            LOG.debug("volume %s is not attached to any target",
+                      self.args['volume_name'])
+        LOG.debug("volumes %s target info %s",
+                  self.args['volume_name'],
+                  tinfo)
 
-        provider_location = None
-        if self.args['snapshot_name']:
-            try:
-                provider_location = self.jdss.get_provider_location(
-                    self.args['volume_name'],
-                    snapshot_name=self.args['snapshot_name'])
-            except jexc.JDSSException as jgerr:
-                LOG.error(jgerr.message)
-                exit(1)
-
-        elif self.args['volume_name']:
-            try:
-                provider_location = self.jdss.get_provider_location(
-                    self.args['volume_name'],
-                    direct=self.args['direct_mode'])
-            except jexc.JDSSException as jgerr:
-                LOG.error(jgerr.message)
-                exit(1)
-        else:
-            sys.exit(1)
-
-        pvs = provider_location.split()
-        ip = ''.join(pvs[0].split(':')[:-1])
-        target_port = pvs[0].split(':')[-1].split(',')[0]
-
-        if target is None:
-            target = pvs[1]
-
-        lun = pvs[2]
-        if self.args['path_format']:
-            out = "ip-{ip}:{port}-iscsi-{target}-lun-{lun}".format(
-                ip=ip,
-                port=target_port,
-                target=target,
-                lun=lun)
-            out = [chr(ord(c)) for c in out]
-            print(''.join(out))
-            return
-
-        out = ''
-        if self.args['host']:
-            out += ' ' + ':'.join(provider_location.split()[0].split(':')[:-1])
-        if self.args['lun']:
-            out += ' ' + lun
-        out = target + out
-
+        out = "{tname} {lun} {hosts}\n".format(tname=tinfo['target'],
+                                               lun=tinfo['lun'],
+                                               hosts=tinfo['vips'])
         print(out)
 
     def list(self):

--- a/jdssc/jdssc/volume.py
+++ b/jdssc/jdssc/volume.py
@@ -90,6 +90,15 @@ class Volume():
                            help='Clone volume name')
 
         delete = parsers.add_parser('delete')
+        delete.add_argument('--target-prefix',
+                            dest='target_prefix',
+                            default=None,
+                            help='''
+                            Pattern for target name prefix.
+                            User can specify plain text or template
+                            in python strftime format.
+                            Default is "iqn.2025-04.iscsi:"
+                            ''')
         delete.add_argument('-c', '--cascade', dest='cascade',
                             action='store_true',
                             default=False,
@@ -178,6 +187,9 @@ class Volume():
     def delete(self):
         res = None
         try:
+            if self.args['target_prefix']:
+                self.jdss.set_target_prefix(self.args['target_prefix'])
+
             res = self.jdss.delete_volume(self.args['volume_name'],
                                           cascade=self.args['cascade'],
                                           print_and_exit=self.args['print'])

--- a/jdssc/jdssc/volumes.py
+++ b/jdssc/jdssc/volumes.py
@@ -254,13 +254,18 @@ class Volumes():
                     continue
 
                 vmid = v['name'][0:match.end()].split('-')[1]
-                line = ("%(name)s %(vmid)s %(size)s\n" % {
+                line = ("%(name)s %(vmid)s %(size)s %(creation)s\n" % {
                     'name': v['name'],
                     'vmid': vmid,
-                    'size': int(v['size'])})
+                    'size': int(v['size']),
+                    'creation': v['creation']
+                })
+
                 sys.stdout.write(line)
             else:
-                line = ("%(name)s %(size)s\n" % {
+                line = ("%(name)s %(size)s %(creation)s\n" % {
                     'name': v['name'],
-                    'size': int(v['size'])})
+                    'size': int(v['size']),
+                    'creation': v['creation']
+                })
                 sys.stdout.write(line)

--- a/jdssc/setup.py
+++ b/jdssc/setup.py
@@ -29,5 +29,7 @@ setup(
     long_description=open('README.txt').read(),
     install_requires=[
         "pytest",
-        "retry"
+        "retry",
+        "pyinotify",
+        "toml"
     ],)


### PR DESCRIPTION
Introduce a major codebase rework of the JovianDSS iSCSI plugin system. 

The new implementation now stores the state of locally mounted volumes in the /etc/joviandss directory.

This update abandons support for the “content volume” feature in favor of the original Proxmox VE NFS plugin. It also removes the JovianDSS LVM plugin from the installation; support for LVM will be reintroduced once ongoing development is complete.

A new option, luns_per_target, allows users to specify how many volumes can be attached to a single target simultaneously. In the current implementation, iSCSI targets are created based on the VM/CT name to which specific volumes are assigned. In other words, volumes belonging to different VM/CT instances will not be grouped under the same target.

Finally, this update improves the naming convention of temporary RAM volumes created during snapshotting of running VMs.
